### PR TITLE
Removed kgextension and wandb from doc/requirements.txt

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -9,9 +9,7 @@ nxontology
 pyitlib
 scipy
 scikit-learn
-kgextension
 pytz
 pandas
-wandb
 numpydoc
 sphinxcontrib-bibtex


### PR DESCRIPTION
Removed to enable ReadTheDocs to build the documentation.