### PR TITLE
Ensure consistent dtypes in preprocessing

### DIFF
--- a/scihfs/preprocessing.py
+++ b/scihfs/preprocessing.py
@@ -102,7 +102,7 @@ class HierarchicalPreprocessor(HierarchicalEstimator):
     def transform(self, X):
         """Transforms dataset to fulfill conditions for feature selection.
 
-        After transformation, if a feature is 1, all of its descendents are 1.
+        After transformation, if a feature is 1, all of its ancestors in the hierarchy are 1 as well.
         Missing columns are added to the dataset.
 
         Parameters
@@ -220,7 +220,7 @@ class HierarchicalPreprocessor(HierarchicalEstimator):
         if num_columns < len(self._columns):
             missing_indices = list(range(num_columns, len(self._columns)))
             for _ in missing_indices:
-                X_ = np.concatenate([X_, np.zeros((num_rows, 1), dtype=int)], axis=1)
+                X_ = np.concatenate([X_, np.zeros((num_rows, 1), dtype=X.dtype)], axis=1)
         return X_
 
     def _build_ancestor_closure(self):

--- a/scihfs/selectors/base.py
+++ b/scihfs/selectors/base.py
@@ -89,7 +89,7 @@ class HierarchicalEstimator(TransformerMixin, BaseEstimator):
             The input samples with only the selected features.
         """
         check_is_fitted(self)
-        X = validate_data(self, X, dtype=None, accept_sparse="csr", reset=False)
+        X = validate_data(self, X, accept_sparse="csr", reset=False)
 
         return X
 

--- a/scihfs/selectors/eagerHierarchicalFeatureSelector.py
+++ b/scihfs/selectors/eagerHierarchicalFeatureSelector.py
@@ -75,7 +75,7 @@ class EagerHierarchicalFeatureSelector(SelectorMixin, HierarchicalEstimator):
         X : array of shape [n_samples, n_selected_features]
             The input samples with only the selected features.
         """
-        X = validate_data(self, X, dtype=None, accept_sparse="csr", reset=False)
+        X = validate_data(self, X, accept_sparse="csr", reset=False)
         return super().transform(X)
 
     def _get_support_mask(self):

--- a/scihfs/tests/test_preprocessing.py
+++ b/scihfs/tests/test_preprocessing.py
@@ -411,3 +411,83 @@ def test_propagate_ones_long_chain_explicit():
     out = pre._propagate_ones(X_added.copy())
     expected = np.array([[1, 1, 1, 1], [1, 1, 1, 0], [1, 0, 0, 0]])
     assert np.array_equal(out, expected)
+
+
+# ---------------------------------------------------------------------------
+# Dtype preservation-related tests. The preprocessor should not change the dtype of the input.
+# ---------------------------------------------------------------------------
+
+
+_DTYPE_PRESERVATION_DTYPES = [
+    np.bool_,
+    np.int8,
+    np.int32,
+    np.int64,
+    np.float32,
+    np.float64,
+]
+
+
+@pytest.mark.parametrize("dtype", _DTYPE_PRESERVATION_DTYPES)
+def test_preprocessor_preserves_input_dtype(dtype):
+    """fit + transform must round-trip the input dtype unchanged."""
+    X_int, hierarchy, columns = _canonical_setup()
+    X = X_int.astype(dtype)
+
+    pre = HierarchicalPreprocessor(hierarchy)
+    pre.fit(X, columns=columns)
+    X_pp = pre.transform(X)
+
+    assert X_pp.dtype == X.dtype, f"dtype mismatch: {X_pp.dtype} != {X.dtype}"
+
+    # The ancestor closure is a semantic mask and stays bool regardless of X.
+    assert pre._ancestor_closure_.dtype == bool
+
+    # Logical content is dtype-independent: the same true-positions as int.
+    expected = np.array(
+        [
+            [1, 0, 0, 1, 1, 0],
+            [0, 1, 0, 1, 1, 0],
+            [0, 0, 1, 1, 0, 1],
+            [1, 0, 0, 1, 1, 0],
+            [0, 0, 1, 1, 0, 1],
+        ]
+    )
+    assert np.array_equal(X_pp.astype(int), expected)
+
+
+def test_preprocessor_accepts_list_of_lists():
+    """Array-likes without a .dtype still get converted to ndarray correctly.
+
+    sklearn's default validate_data treats list inputs as float64. The point
+    is that the input is accepted and produces a logically correct result.
+    """
+    X_int, hierarchy, columns = _canonical_setup()
+    X_list = X_int.tolist()
+
+    pre = HierarchicalPreprocessor(hierarchy)
+    pre.fit(X_list, columns=columns)
+    X_pp = pre.transform(X_list)
+
+    assert isinstance(X_pp, np.ndarray)
+    expected = np.array(
+        [
+            [1, 0, 0, 1, 1, 0],
+            [0, 1, 0, 1, 1, 0],
+            [0, 0, 1, 1, 0, 1],
+            [1, 0, 0, 1, 1, 0],
+            [0, 0, 1, 1, 0, 1],
+        ]
+    )
+    assert np.array_equal(X_pp.astype(int), expected)
+
+
+def test_preprocessor_rejects_nan():
+    """validate_data's ensure_all_finite check still rejects NaN."""
+    X_int, hierarchy, columns = _canonical_setup()
+    X = X_int.astype(np.float64)
+    X[0, 0] = np.nan
+
+    pre = HierarchicalPreprocessor(hierarchy)
+    with pytest.raises(ValueError):
+        pre.fit(X, columns=columns)


### PR DESCRIPTION
Fixed two problems related to dtype consistency in preprocessing:
- Concatenation in `HierarchicalPreprocessor.transform()` altered dtype of data array (X).
- Two instances of `validate_data` with dtype=None argument which would have silently accepted non-conformant data types.

Added corresponding tests to ensure datatype consistency (LLM-generated, manually validated).