### PR TITLE
Added sparse support and consistent format throughout preprocessing

### DIFF
--- a/scihfs/preprocessing.py
+++ b/scihfs/preprocessing.py
@@ -91,7 +91,9 @@ class HierarchicalPreprocessor(HierarchicalEstimator):
             Returns self.
         """
 
-        X = validate_data(self, X, accept_sparse=True)
+        X = validate_data(self, X, accept_sparse="csr")
+        if sp.issparse(X):
+            X = sp.csr_array(X)
         check_bool_dtype(X)
         super().fit(X, y, columns)
         self._columns = [
@@ -127,8 +129,13 @@ class HierarchicalPreprocessor(HierarchicalEstimator):
         # Check is fit had been called
         check_is_fitted(self, "is_fitted_")
 
-        # Input validation (also checks feature count matches fit)
-        X = validate_data(self, X, accept_sparse=True, reset=False)
+        # Input validation.
+        # Any sparse input (csr/csc/coo, matrix or array) is accepted, and then normalized
+        # to CSR by validate_data. To provide consistent behaviour downstream, any output is then coerced to the recommended csr_array
+        # type so the rest of the transform pipeline sees only one single sparse type with a predictable behaviour.
+        X = validate_data(self, X, accept_sparse="csr", reset=False)
+        if sp.issparse(X):
+            X = sp.csr_array(X)
         check_bool_dtype(X)
 
         X_ = self._add_columns(X)
@@ -214,7 +221,9 @@ class HierarchicalPreprocessor(HierarchicalEstimator):
     def _add_columns(self, X):
         """Adds missing columns to the dataset.
 
-        Missing columns are added and all values are set to 0.
+        Missing columns are added and all values are set to 0. Sparse inputs
+        are padded with a sparse zero block via ``scipy.sparse.hstack``
+        dense inputs use a single ``np.concatenate``.
 
         Parameters
         ----------
@@ -223,15 +232,18 @@ class HierarchicalPreprocessor(HierarchicalEstimator):
         Returns
         -------
         X_ : array of shape [n_samples, n_new_features]
-            The dataset with the added columns.
+            The dataset with the added columns. Output format matches input
+            format (CSR in -> CSR out; dense in -> dense out).
         """
-        X_ = X
         num_rows, num_columns = X.shape
-        if num_columns < len(self._columns):
-            missing_indices = list(range(num_columns, len(self._columns)))
-            for _ in missing_indices:
-                X_ = np.concatenate([X_, np.zeros((num_rows, 1), dtype=X.dtype)], axis=1)
-        return X_
+        n_extra = len(self._columns) - num_columns
+        if n_extra <= 0:
+            return X
+        if sp.issparse(X):
+            padding = sp.csr_array((num_rows, n_extra), dtype=X.dtype)
+            return sp.hstack([X, padding], format="csr")
+        padding = np.zeros((num_rows, n_extra), dtype=X.dtype)
+        return np.concatenate([X, padding], axis=1)
 
     def _build_ancestor_closure(self):
         """Precompute the ancestor closure matrix indexed by column position.
@@ -241,7 +253,7 @@ class HierarchicalPreprocessor(HierarchicalEstimator):
         of the node mapped to column i. The virtual "ROOT" node is excluded
         since it has no corresponding column.
 
-        Under the assumption that ancestor closures of ontologies are very sparse, this matrix is stored as a ``scipy.sparse.csr_matrix`` of dtype ``bool`` – primarily to save memory (but also to speed up the matmul in ``_propagate_ones``).
+        Under the assumption that ancestor closures of ontologies are very sparse, this matrix is stored as a ``scipy.sparse.csr_array`` of dtype ``bool`` – primarily to save memory (but also to speed up the matmul in ``_propagate_ones``).
         """
         n_cols = len(self._columns)
         rows: list[int] = []
@@ -256,7 +268,7 @@ class HierarchicalPreprocessor(HierarchicalEstimator):
                 cols.append(node_to_col[anc])
 
         data = np.ones(len(rows), dtype=bool)
-        self._ancestor_closure_ = sp.csr_matrix(
+        self._ancestor_closure_ = sp.csr_array(
             (data, (rows, cols)), shape=(n_cols, n_cols), dtype=bool
         )
 
@@ -264,7 +276,9 @@ class HierarchicalPreprocessor(HierarchicalEstimator):
         """Update the dataset to fulfill the 0-1-propagation rule.
 
         If a feature in the dataset is 1, all of its ancestors in the
-        sample are set to 1.
+        sample are set to 1. Sparse inputs stay sparse end-to-end (the
+        intermediate ``X @ closure`` product is sparse, and elementwise OR
+        is realised via ``sparse.maximum``); dense inputs use ``|``.
 
         Parameters
         ----------
@@ -274,14 +288,16 @@ class HierarchicalPreprocessor(HierarchicalEstimator):
         Returns
         -------
         X : array of shape [n_samples, n_new_features]
-            The dataset with updated feature values.
+            The dataset with updated feature values. Output format matches
+            input format (CSR in -> CSR out; dense in -> dense out).
         """
         # Cast X to bool so scipy's sparse matmul keeps OR-style semantics
         # (numeric X would otherwise return path counts, not a bool mask).
         X_bool = X.astype(bool, copy=False)
-        propagation = np.asarray(X_bool @ self._ancestor_closure_)
-        X_propagated = X_bool | propagation
-        return X_propagated.astype(X.dtype)
+        propagation = X_bool @ self._ancestor_closure_
+        if sp.issparse(X):
+            return X_bool.maximum(propagation).tocsr()
+        return X_bool | propagation
 
     def _adjust_node_names(self):
         """Adjust node names in hierarchy and _columns.

--- a/scihfs/tests/test_preprocessing.py
+++ b/scihfs/tests/test_preprocessing.py
@@ -482,23 +482,136 @@ def test_preprocessor_accepts_bool_dense():
 
 
 def test_preprocessor_accepts_bool_sparse():
-    """csr_matrix(dtype=bool) input passes the bool-dtype check.
+    """csr_array(dtype=bool) input passes the bool-dtype check and round-trips
+    through fit + transform without densifying.
 
     Tests whether the validator treats ``X.dtype`` uniformly for dense and sparse matrices and yields the is_fitted_ attribute.
     """
     X_dense, hierarchy, columns = _canonical_setup()
-    X = sp.csr_matrix(X_dense)
+    X = sp.csr_array(X_dense)
     assert X.dtype == np.bool_
 
     pre = HierarchicalPreprocessor(hierarchy)
     pre.fit(X, columns=columns)
     assert pre.is_fitted_
 
+    X_pp = pre.transform(X)
+    assert isinstance(X_pp, sp.sparray)
+    assert X_pp.format == "csr"
+    assert X_pp.dtype == np.bool_
+    assert X_pp.shape == (X_dense.shape[0], len(pre._columns))
+
+
+# ---------------------------------------------------------------------------
+# Sparse input support.
+#
+# fit + transform must work end-to-end on scipy.sparse.csr_matrix(bool) and
+# return CSR(bool) output equivalent (cell-by-cell) to the dense path on the
+# same input. Sparse and dense paths must never silently cross over.
+# ---------------------------------------------------------------------------
+
+
+def test_preprocessor_sparse_canonical_equivalence():
+    """Canonical example: sparse path yields the same matrix as dense."""
+    X_dense, hierarchy, columns = _canonical_setup()
+    X_sparse = sp.csr_array(X_dense)
+
+    pre_d = HierarchicalPreprocessor(hierarchy)
+    pre_d.fit(X_dense, columns=columns)
+    out_d = pre_d.transform(X_dense)
+
+    pre_s = HierarchicalPreprocessor(hierarchy)
+    pre_s.fit(X_sparse, columns=columns)
+    out_s = pre_s.transform(X_sparse)
+
+    assert not sp.issparse(out_d)
+    assert isinstance(out_s, sp.sparray)
+    assert out_s.format == "csr"
+    assert out_d.dtype == np.bool_
+    assert out_s.dtype == np.bool_
+    assert np.array_equal(out_s.toarray(), out_d)
+    assert np.array_equal(out_s.toarray().astype(int), _EXPECTED_CANONICAL)
+
+
+def test_scipy_sparse_bool_matmul_preserves_bool():
+    """Test whether matmul (``@``) and ``maximum()`` preserve dtype in scipy sparse arrays. This behaviour is not immediately obvious from the scipy docs at first glance, so this is just a defensive test."""
+    a = sp.csr_array(np.array([[True, False], [False, True]]))
+    b = sp.csr_array(np.array([[True, True], [False, True]]))
+    assert (a @ b).dtype == np.bool_
+    assert a.maximum(b).dtype == np.bool_
+
+
+def test_preprocessor_accepts_csc_input():
+    """CSC input is accepted (and normalized to csr_array on output)."""
+    X_dense, hierarchy, columns = _canonical_setup()
+    X_csc = sp.csc_array(X_dense)
+    assert X_csc.format == "csc"
+
+    pre = HierarchicalPreprocessor(hierarchy)
+    pre.fit(X_csc, columns=columns)
+    out = pre.transform(X_csc)
+
+    assert isinstance(out, sp.sparray)
+    assert out.format == "csr"
+    assert out.dtype == np.bool_
+    assert np.array_equal(out.toarray().astype(int), _EXPECTED_CANONICAL)
+
+
+def test_preprocessor_accepts_coo_input():
+    """COO input is accepted (and normalized to csr_array on output)."""
+    X_dense, hierarchy, columns = _canonical_setup()
+    X_coo = sp.coo_array(X_dense)
+    assert X_coo.format == "coo"
+
+    pre = HierarchicalPreprocessor(hierarchy)
+    pre.fit(X_coo, columns=columns)
+    out = pre.transform(X_coo)
+
+    assert isinstance(out, sp.sparray)
+    assert out.format == "csr"
+    assert out.dtype == np.bool_
+    assert np.array_equal(out.toarray().astype(int), _EXPECTED_CANONICAL)
+
+
+def test_preprocessor_normalizes_legacy_csr_matrix_to_csr_array():
+    """Legacy ``csr_matrix`` input is accepted and normalized to ``csr_array``.
+
+    scipy encourages the use of csr_array over csr_matrix.
+    Since csr_matrix is just a different representation of the same underlying sparse data, but has a different API, the preprocessor accepts csr_matrix for backward compatibility but internally converts it to csr_array. This ensures consistent behaviour for all downstream operations.
+    """
+    X_dense, hierarchy, columns = _canonical_setup()
+    X_legacy = sp.csr_matrix(X_dense)
+    assert isinstance(X_legacy, sp.spmatrix)
+
+    pre = HierarchicalPreprocessor(hierarchy)
+    pre.fit(X_legacy, columns=columns)
+    out = pre.transform(X_legacy)
+
+    assert isinstance(out, sp.sparray)
+    assert not isinstance(out, sp.spmatrix)
+    assert out.format == "csr"
+    assert out.dtype == np.bool_
+    assert np.array_equal(out.toarray().astype(int), _EXPECTED_CANONICAL)
+
+
+def test_preprocessor_sparse_dense_paths_do_not_cross_format():
+    """Dense in -> dense out. Sparse in -> sparse out. No silent crossover."""
+    X_dense, hierarchy, columns = _canonical_setup()
+    X_sparse = sp.csr_array(X_dense)
+
+    pre_d = HierarchicalPreprocessor(hierarchy)
+    pre_d.fit(X_dense, columns=columns)
+    assert isinstance(pre_d.transform(X_dense), np.ndarray)
+
+    pre_s = HierarchicalPreprocessor(hierarchy)
+    pre_s.fit(X_sparse, columns=columns)
+    assert sp.issparse(pre_s.transform(X_sparse))
+
 
 def test_preprocessor_rejects_non_bool_sparse():
     """Sparse int input must be rejected with the same bool-dtype error."""
     X_dense, hierarchy, columns = _canonical_setup()
-    X = sp.csr_matrix(X_dense.astype(np.int8))
+    X = sp.csr_array(X_dense.astype(np.int8))
     assert X.dtype == np.int8
 
     pre = HierarchicalPreprocessor(hierarchy)


### PR DESCRIPTION
Throughout preprocessing:
- Specified *csr* as sparse representation.
- Implemented dedicated sparse data processing paths where it deviates from dense.
- Ensured that csr remains csr, and dense remains dense.
- Enforce *csr_array* type (instead of *csr_matrix*) to stay consistent with scipy's recommendations.

Also added tests to check that behaviour (LLM-generated, manually curated).