### PR TITLE
Preprocessor dataframe compatibility

### DIFF
--- a/examples/eager_learning_example.py
+++ b/examples/eager_learning_example.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 """
+CAUTION: Work in progress! The API (and this example) is not yet stable and may change without deprecation. Please reach out if you want to use or contribute to this library.
+
 Eager learning
 =====================
 
@@ -50,3 +52,45 @@ selector.fit(X, y, columns=columns)
 X_transformed = selector.transform(X)
 
 print(X_transformed)
+
+# %%
+# DataFrame + DiGraph: the one-call preprocessing path
+# ----------------------------------------------------
+# ``HierarchicalPreprocessor`` accepts a pandas ``DataFrame`` together with a
+# named ``networkx.DiGraph`` hierarchy. The column-to-node mapping is then
+# derived automatically from the DataFrame's column names, so neither
+# ``nx.to_numpy_array`` nor an explicit ``columns`` argument is needed.
+
+import pandas as pd
+
+from scihfs.preprocessing import HierarchicalPreprocessor
+
+# Bool DataFrame: each column is a (leaf) feature named after a hierarchy node.
+df = pd.DataFrame(
+    {
+        "dog": [True, False, False],
+        "cat": [False, True, False],
+        "eagle": [False, False, True],
+    }
+)
+
+# Named hierarchy. Nodes carry meaningful labels instead of column indices.
+graph = nx.DiGraph(
+    [
+        ("animal", "mammal"),
+        ("animal", "bird"),
+        ("mammal", "dog"),
+        ("mammal", "cat"),
+        ("bird", "eagle"),
+    ]
+)
+
+# One call: no nx.to_numpy_array, no create_mapping_columns_to_nodes, no columns=.
+preprocessor = HierarchicalPreprocessor(graph)
+
+# Opt into DataFrame output to keep the hierarchy node names on the columns.
+preprocessor.set_output(transform="pandas")
+preprocessor.fit(df)
+df_transformed = preprocessor.transform(df)
+
+print(df_transformed)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
     "pytest-cov>=6.0.0,<7",
     "twine>=6.1.0,<7",
     "tomli>=2.2.1,<3",
+    "polars>=1.0,<2",
 ]
 
 [build-system]

--- a/scihfs/data_utils.py
+++ b/scihfs/data_utils.py
@@ -12,6 +12,9 @@ def create_mapping_columns_to_nodes(data: pd.DataFrame, hierarchy: nx.DiGraph):
     to the corresponding indices is created so that after the transformation
     the correct nodes in the hierarchy can still be found for each column.
 
+    .. note::
+        This helper is no longer required for the expected preprocessing workflow (DataFrame for data and nx.DiGraph for hierarchy inputs to HierarchicalPreprocessor), but remains fully supported for all other use cases.
+
     Parameters
     ----------
     data : pd.Dataframe

--- a/scihfs/preprocessing.py
+++ b/scihfs/preprocessing.py
@@ -14,6 +14,7 @@ from sklearn.utils.validation import check_is_fitted, validate_data
 
 from scihfs.helpers import check_bool_dtype, shrink_dag
 from scihfs.selectors import HierarchicalEstimator
+from scihfs.selectors.base import ORIGINAL_NODE_IDENTIFIER
 
 
 class ColumnNotInHierarchyWarning(UserWarning):
@@ -39,13 +40,25 @@ class HierarchicalPreprocessor(HierarchicalEstimator):
     for numeric features is planned as a future enhancement.
     """
 
-    def __init__(self, hierarchy: np.ndarray = None):
+    def __init__(self, hierarchy=None):
         """Initializes a HierarchicalPreprocessor.
 
         Parameters
         ----------
-        hierarchy : np.ndarray
-                    The hierarchy graph as an adjacency matrix."""
+        hierarchy : np.ndarray or nx.DiGraph
+                    The hierarchy graph. Either an adjacency matrix
+                    (``np.ndarray``), whose nodes are the integer column
+                    positions, or a ``networkx.DiGraph`` whose nodes carry
+                    names (typically strings matching the DataFrame columns).
+                    Note: ``None`` is accepted for scikit-learn ``clone()`` compatibility but raises ``TypeError`` in ``fit``.
+
+        .. note::
+            When the hierarchy is a named ``DiGraph`` and X is passed
+            to ``fit`` as a pandas ``DataFrame``, the column-to-node
+            mapping is derived automatically from the feature names,
+            so the ``columns`` argument of ``fit`` can be omitted.
+
+        """
         self.hierarchy = hierarchy
 
     def fit(self, X, y=None, columns=None):
@@ -71,19 +84,29 @@ class HierarchicalPreprocessor(HierarchicalEstimator):
 
         Parameters
         ----------
-        X : {array-like, sparse matrix}, shape (n_samples, n_features)
+        X : {array-like, sparse matrix, DataFrame}, shape (n_samples, n_features)
             The training input samples. Must be bool-dtype. Non-binary
             (numeric) inputs raise ``ValueError`` until the planned
-            sum-propagation mode will be implemented.
+            sum-propagation mode will be implemented. A DataFrame (pandas, or
+            any library scikit-learn recognises through the dataframe
+            interchange protocol (up to v1.8.x) or the narwhals library (as of 1.9.0) such as polars) is accepted: its column names
+            are captured as ``feature_names_in_`` and used to auto-derive
+            ``columns`` (see below). No DataFrame library is imported directly;
+            support comes entirely through scikit-learn's input plumbing.
 
         y : None
             This transformer does not require a target variable, but the pipeline API
             requires this parameter.
 
         columns : list or None, length n_features
-            The mapping from the hierarchy graph's nodes to the columns in X. If this
+            The mapping from the columns in X to the hierarchy graph's nodes. If this
             parameter is None, the columns in X and the corresponding nodes in the
-            hierarchy are expected to be in the same order.
+            hierarchy are expected to be in the same order -- EXCEPT when X is a
+            DataFrame and ``hierarchy`` is an ``nx.DiGraph``: then the mapping is
+            derived automatically by matching feature names to node names, and passing
+            ``columns`` separately is unnecessary. Passing a DataFrame with ``columns=None``
+            while ``hierarchy`` is an adjacency ndarray raises ``ValueError`` (there
+            are no node names to match against).
 
         Returns
         -------
@@ -95,7 +118,18 @@ class HierarchicalPreprocessor(HierarchicalEstimator):
         if sp.issparse(X):
             X = sp.csr_array(X)
         check_bool_dtype(X)
-        super().fit(X, y, columns)
+
+        if columns is None and getattr(self, "feature_names_in_", None) is not None:
+            # For the case that X was a DataFrame (and feature_names_in_ has been set automatically in validate_data): derive the column->node mapping from the captured feature names.
+            # Done here (and not in the base class) because
+            # auto-derivation is preprocessor-specific FOR NOW – this behaviour might change in the future.
+            columns = self._auto_derive_columns()
+
+        # Reuse the base hierarchy setup WITHOUT a second validate_data call:
+        # re-validating would drop feature_names_in_ (needed by
+        # get_feature_names_out / set_output) and is redundant work here.
+        self._fit_hierarchy(columns)
+
         self._columns = [
             column if column < len(self.hierarchy) else -1 for column in self._columns
         ]
@@ -107,6 +141,42 @@ class HierarchicalPreprocessor(HierarchicalEstimator):
         self._build_ancestor_closure()
         self.is_fitted_ = True
         return self
+
+    def _auto_derive_columns(self):
+        """Derive the column->node mapping from DataFrame feature names.
+
+        Called from ``fit`` when X is a pandas ``DataFrame`` (so
+        ``feature_names_in_`` is set) and ``columns`` was not supplied. Each
+        captured feature name is looked up against the hierarchy's node names;
+        names with no matching node map to ``-1`` (handled downstream by
+        ``_extend_dag``, which adds them under ROOT with a warning).
+
+        Node names are compared as strings because scikit-learn coerces
+        DataFrame column labels to ``str`` in ``feature_names_in_``. This lets
+        a ``DiGraph`` with integer node names still match a DataFrame whose
+        (string) column labels equal those integers.
+
+        Returns
+        -------
+        columns : list of int
+            The derived column->node-position mapping, in feature order.
+
+        Raises
+        ------
+        ValueError
+            If the hierarchy is not a ``DiGraph`` (an adjacency ndarray has no
+            node names to match against).
+        """
+        if not isinstance(self.hierarchy, nx.DiGraph):
+            raise ValueError(
+                "Cannot auto-derive columns from DataFrame feature names "
+                "because hierarchy is an ndarray (no node names). Either pass "
+                "hierarchy as nx.DiGraph with named nodes, or supply columns "
+                "explicitly."
+            )
+        nodes = list(self.hierarchy.nodes)
+        name_to_position = {str(node): i for i, node in enumerate(nodes)}
+        return [name_to_position.get(str(name), -1) for name in self.feature_names_in_]
 
     def transform(self, X):
         """Transforms dataset to fulfill conditions for feature selection.
@@ -158,6 +228,43 @@ class HierarchicalPreprocessor(HierarchicalEstimator):
         else:
             raise RuntimeError("Instance has not been fitted.")
 
+    def get_feature_names_out(self, input_features=None):
+        """Map each output column to its hierarchy node name.
+
+        Enables ``set_output(transform="pandas")`` (or ``"polars"``) so that
+        ``transform`` returns a labelled DataFrame. The output has one name per
+        entry of ``self._columns`` (in order), i.e. including the ancestor and
+        any auto-added columns appended during ``fit``.
+
+        Names are recovered from the ``ORIGINAL_NODE_IDENTIFIER`` node attribute
+        stamped in ``_set_hierarchy`` / ``_extend_dag`` (which survives the
+        relabel/shrink/adjust passes). This traces each output column back to its
+        original identity: the node name for a ``DiGraph`` hierarchy, the original
+        integer index for an adjacency-matrix hierarchy (NOT the post-shrink
+        renumbering), or the input feature name for an orphan column added under
+        ROOT (when X was a DataFrame). Only orphan columns from a nameless X
+        (e.g. a plain ndarray) lack the attribute and fall back to ``"x<node>"``.
+
+        Parameters
+        ----------
+        input_features : array-like of str or None
+            Unused; present for scikit-learn API compatibility.
+
+        Returns
+        -------
+        feature_names_out : ndarray of str, shape (n_output_features,)
+        """
+        check_is_fitted(self, "is_fitted_")
+        names = []
+        for node in self._columns:
+            data = self._hierarchy_graph.nodes[node]
+            if ORIGINAL_NODE_IDENTIFIER in data:
+                name = data[ORIGINAL_NODE_IDENTIFIER]
+            else:
+                name = f"x{node}"
+            names.append(str(name))
+        return np.asarray(names, dtype=object)
+
     def _extend_dag(self):
         """Adds missing nodes to the hierarchy graph.
 
@@ -178,13 +285,20 @@ class HierarchicalPreprocessor(HierarchicalEstimator):
                 if column_index in self._hierarchy_graph.nodes:
                     # column_index has name conflict with an existing node
                     # so we add a node with next available id
-                    self._hierarchy_graph.add_edge("ROOT", next_available_node_id)
-                    self._columns[column_index] = next_available_node_id
+                    new_node = next_available_node_id
                     next_available_node_id += 1
                 else:
                     # directly add the column as a node under "ROOT"
-                    self._hierarchy_graph.add_edge("ROOT", column_index)
-                    self._columns[column_index] = column_index
+                    new_node = column_index
+                self._hierarchy_graph.add_edge("ROOT", new_node)
+                self._columns[column_index] = new_node
+                # If X was a DataFrame, stamp the input feature name on this
+                # orphan node so get_feature_names_out can label it properly
+                # instead of falling back to "x<node>".
+                if getattr(self, "feature_names_in_", None) is not None:
+                    self._hierarchy_graph.nodes[new_node][ORIGINAL_NODE_IDENTIFIER] = str(
+                        self.feature_names_in_[column_index]
+                    )
 
         # Warn user for all columns that were not in hierarchy
         if columns_without_node:

--- a/scihfs/selectors/base.py
+++ b/scihfs/selectors/base.py
@@ -9,6 +9,10 @@ from sklearn.utils.validation import check_is_fitted, validate_data
 
 from scihfs.helpers import add_virtual_root_node
 
+# Node-attribute key for recording a node's original identity (name or index) in the hierarchy graph. Left untouched by all operations on the graph.
+# Consumed by get_feature_names_out to map back to original node names / indexes.
+ORIGINAL_NODE_IDENTIFIER = "_scihfs_original_node_identifier"
+
 
 class HierarchicalEstimator(TransformerMixin, BaseEstimator):
     """Base class for estimators using hierarchical data.
@@ -18,13 +22,16 @@ class HierarchicalEstimator(TransformerMixin, BaseEstimator):
     selection classes or data preprocessors that use hierarchical data.
     """
 
-    def __init__(self, hierarchy: np.ndarray = None):
+    def __init__(self, hierarchy=None):
         """Initializes a HierarchicalEstimator.
 
         Parameters
         ----------
-        hierarchy : np.ndarray
-                    The hierarchy graph as an adjacency matrix."""
+        hierarchy : np.ndarray or nx.DiGraph
+                    The hierarchy graph, given either as an adjacency matrix
+                    (``np.ndarray``) or as a ``networkx.DiGraph`` with named
+                    nodes. ``None`` is accepted for scikit-learn ``clone()``
+                    compatibility but raises ``TypeError`` in ``fit``."""
         self.hierarchy = hierarchy
 
     def __sklearn_tags__(self):
@@ -63,6 +70,26 @@ class HierarchicalEstimator(TransformerMixin, BaseEstimator):
         if self.hierarchy is None:
             raise TypeError("Hierarchy is None but is required.")
         X = validate_data(self, X, accept_sparse=True)
+        self._fit_hierarchy(columns)
+
+        return self
+
+    def _fit_hierarchy(self, columns):
+        """Set ``_columns`` and build ``_hierarchy_graph`` from a validated X.
+
+        Split out from ``fit`` so that subclasses performing their own input
+        validation (e.g. ``HierarchicalPreprocessor``, which must read
+        ``feature_names_in_`` before any second ``validate_data`` call would
+        drop it) can reuse the hierarchy setup without re-validating X.
+
+        Assumes ``validate_data`` has already run and set ``n_features_in_``.
+
+        Parameters
+        ----------
+        columns : list or None
+            The mapping from the hierarchy graph's nodes to the columns in X.
+            If None, positional 1:1 ordering is assumed.
+        """
         if columns:
             self._columns = columns
         else:
@@ -70,8 +97,6 @@ class HierarchicalEstimator(TransformerMixin, BaseEstimator):
 
         self._set_hierarchy()
         self._check_dag()
-
-        return self
 
     def transform(self, X):
         """Reduce X to the selected features.
@@ -116,11 +141,60 @@ class HierarchicalEstimator(TransformerMixin, BaseEstimator):
             raise ValueError("The hierarchy graph is not a directed acyclic graph.")
 
     def _set_hierarchy(self):
+        """Build ``self._hierarchy_graph`` from ``self.hierarchy``.
+
+        The ``hierarchy`` parameter is accepted in two formats:
+
+        - ``np.ndarray``: interpreted as an adjacency matrix; nodes are the
+          integer row/column positions (existing behaviour).
+        - ``nx.DiGraph``: nodes may carry arbitrary (e.g. string) names. They
+          are relabelled to integer positions ``0..n-1`` (preserving node
+          order) so the rest of the pipeline keeps operating on integer node
+          names.
+
+        In both cases each node is stamped with an ``ORIGINAL_NODE_IDENTIFIER``
+        attribute recording its original identity -- the integer index for an
+        adjacency matrix, the node name for a ``DiGraph``. The attribute travels
+        with the node through the later relabel/shrink/adjust passes (networkx
+        preserves node attributes across ``relabel_nodes``), so
+        ``get_feature_names_out`` can map each output column back to its original
+        node even after the internal renumbering.
+
+        The user's original ``DiGraph`` is never mutated: ``relabel_nodes`` is
+        called with ``copy=True`` and the virtual ROOT is added to the copy.
+
+        After dispatch the virtual "ROOT" node is added to connect components.
+
+        Raises
+        ------
+        TypeError
+            If ``hierarchy`` is None or neither ``np.ndarray`` nor ``nx.DiGraph``.
         """
-        Assign hierarchy graph to self._hierarchy_graph
-        after adding ROOT node to connect components.
-        """
-        hierarchy_graph = nx.from_numpy_array(self.hierarchy, create_using=nx.DiGraph)
+        if self.hierarchy is None:
+            raise TypeError("Hierarchy is None but is required.")
+        if isinstance(self.hierarchy, np.ndarray):
+            hierarchy_graph = nx.from_numpy_array(self.hierarchy, create_using=nx.DiGraph)
+            # Adjacency nodes already ARE their original integer indices.
+            original_identifiers = {
+                node_index: node_index for node_index in hierarchy_graph.nodes
+            }
+        elif isinstance(self.hierarchy, nx.DiGraph):
+            node_names = list(self.hierarchy.nodes)
+            mapping = {
+                node_name: position for position, node_name in enumerate(node_names)
+            }
+            hierarchy_graph = nx.relabel_nodes(self.hierarchy, mapping, copy=True)
+            original_identifiers = {
+                position: node_name for position, node_name in enumerate(node_names)
+            }
+        else:
+            raise TypeError(
+                f"hierarchy must be np.ndarray or nx.DiGraph, "
+                f"got {type(self.hierarchy)}."
+            )
+        nx.set_node_attributes(
+            hierarchy_graph, original_identifiers, ORIGINAL_NODE_IDENTIFIER
+        )
         # Add "ROOT" node and connect components if there are multiple
         self._hierarchy_graph = add_virtual_root_node(hierarchy_graph)
 

--- a/scihfs/tests/test_preprocessing.py
+++ b/scihfs/tests/test_preprocessing.py
@@ -661,6 +661,368 @@ def test_error_message_mentions_astype_bool():
         pre.fit(X, columns=columns)
 
 
+# ---------------------------------------------------------------------------
+# DiGraph hierarchy + DataFrame X acceptance and column auto-derivation.
+#
+# The canonical example is reused so the new (DataFrame + DiGraph) happy path
+# can be pinned cell-by-cell against the established ndarray + explicit-columns
+# result in _EXPECTED_CANONICAL.
+# ---------------------------------------------------------------------------
+
+
+def _canonical_digraph():
+    """Named DiGraph equivalent of the canonical ndarray hierarchy.
+
+    Node insertion order is animal, mammal, bird, fish, dog, cat, eagle, trout,
+    i.e. positions 4/5/6 are dog/cat/eagle -- matching nx.to_numpy_array(graph)
+    used by _canonical_setup, so both paths yield identical output.
+    """
+    return nx.DiGraph(
+        [
+            ("animal", "mammal"),
+            ("animal", "bird"),
+            ("animal", "fish"),
+            ("mammal", "dog"),
+            ("mammal", "cat"),
+            ("bird", "eagle"),
+            ("fish", "trout"),
+        ]
+    )
+
+
+def _canonical_dataframe():
+    """Bool DataFrame matching _canonical_setup's X, with named columns."""
+    return pd.DataFrame(
+        {
+            "dog": [1, 0, 0, 1, 0],
+            "cat": [0, 1, 0, 0, 0],
+            "eagle": [0, 0, 1, 0, 1],
+        }
+    ).astype(bool)
+
+
+def test_preprocessor_accepts_digraph_hierarchy_with_ndarray_X():
+    """DiGraph hierarchy + ndarray X + explicit columns == ndarray-hierarchy path."""
+    X, _, columns = _canonical_setup()  # X is bool ndarray, columns == [4, 5, 6]
+    graph = _canonical_digraph()
+
+    pre = HierarchicalPreprocessor(graph)
+    pre.fit(X, columns=columns)
+    out = pre.transform(X)
+
+    assert isinstance(out, np.ndarray)
+    assert out.dtype == np.bool_
+    assert np.array_equal(out.astype(int), _EXPECTED_CANONICAL)
+
+
+def test_preprocessor_accepts_dataframe_with_ndarray_hierarchy():
+    """DataFrame X + ndarray hierarchy + explicit columns; output stays ndarray."""
+    _, hierarchy, columns = _canonical_setup()
+    df = _canonical_dataframe()
+
+    pre = HierarchicalPreprocessor(hierarchy)
+    pre.fit(df, columns=columns)
+    out = pre.transform(df)
+
+    assert isinstance(out, np.ndarray)  # ndarray by default, not a DataFrame
+    assert out.dtype == np.bool_
+    assert np.array_equal(out.astype(int), _EXPECTED_CANONICAL)
+
+
+def test_preprocessor_accepts_dataframe_with_digraph_hierarchy_explicit_columns():
+    """DataFrame X + DiGraph hierarchy + explicit columns."""
+    _, _, columns = _canonical_setup()
+    df = _canonical_dataframe()
+    graph = _canonical_digraph()
+
+    pre = HierarchicalPreprocessor(graph)
+    pre.fit(df, columns=columns)
+    out = pre.transform(df)
+
+    assert np.array_equal(out.astype(int), _EXPECTED_CANONICAL)
+
+
+def test_preprocessor_autoderives_columns_when_dataframe_and_digraph():
+    """DataFrame X + DiGraph + columns=None: auto-derive equals explicit-columns."""
+    _, _, columns = _canonical_setup()
+    df = _canonical_dataframe()
+    graph = _canonical_digraph()
+
+    pre_auto = HierarchicalPreprocessor(graph)
+    pre_auto.fit(df)  # no columns=
+    assert pre_auto.is_fitted_
+
+    pre_explicit = HierarchicalPreprocessor(graph)
+    pre_explicit.fit(df, columns=columns)
+
+    out_auto = pre_auto.transform(df)
+    out_explicit = pre_explicit.transform(df)
+    assert np.array_equal(out_auto, out_explicit)
+    assert np.array_equal(out_auto.astype(int), _EXPECTED_CANONICAL)
+
+
+def test_preprocessor_rejects_dataframe_with_ndarray_hierarchy_no_columns():
+    """DataFrame X + ndarray hierarchy + columns=None raises a clear ValueError."""
+    _, hierarchy, _ = _canonical_setup()
+    df = _canonical_dataframe()
+
+    pre = HierarchicalPreprocessor(hierarchy)
+    with pytest.raises(ValueError, match="Cannot auto-derive columns"):
+        pre.fit(df)
+
+
+# --- Input-validation edge cases -------------------------------------------
+
+
+def test_dataframe_with_unknown_column():
+    """A DataFrame column absent from the graph maps to -1 and warns (ROOT add)."""
+    graph = _canonical_digraph()
+    df = _canonical_dataframe()
+    df["unicorn"] = [False, True, False, False, True]  # not a node in graph
+
+    pre = HierarchicalPreprocessor(graph)
+    with pytest.warns(ColumnNotInHierarchyWarning):
+        pre.fit(df)  # auto-derive path
+
+
+def test_orphan_dataframe_column_keeps_its_name_in_feature_names_out():
+    """An orphan DataFrame column (absent from the graph) is labelled with its
+    own feature name in get_feature_names_out, not the "x<node>" fallback."""
+    graph = _canonical_digraph()
+    df = _canonical_dataframe()
+    df["unicorn"] = [False, True, False, False, True]
+
+    pre = HierarchicalPreprocessor(graph)
+    with pytest.warns(ColumnNotInHierarchyWarning):
+        pre.fit(df)
+
+    names = list(pre.get_feature_names_out())
+    assert "unicorn" in names
+    assert not any(n.startswith("x") for n in names)
+    # round-trips through set_output too
+    pre2 = HierarchicalPreprocessor(graph)
+    pre2.set_output(transform="pandas")
+    with pytest.warns(ColumnNotInHierarchyWarning):
+        pre2.fit(df)
+    out = pre2.transform(df)
+    assert "unicorn" in out.columns
+
+
+def test_orphan_ndarray_column_falls_back_to_x_node():
+    """With a nameless (ndarray) X, an orphan column has no feature name to
+    recover, so it falls back to the "x<node>" label."""
+    # Two columns; hierarchy only knows node 0, so column 1 is an orphan.
+    X = np.array([[True, False], [False, True]])
+    hierarchy = nx.to_numpy_array(nx.DiGraph([(0, 1)]))  # nodes 0, 1
+
+    pre = HierarchicalPreprocessor(hierarchy)
+    with pytest.warns(ColumnNotInHierarchyWarning):
+        pre.fit(X, columns=[0, -1])
+
+    names = list(pre.get_feature_names_out())
+    assert any(n.startswith("x") for n in names)
+
+
+def test_dataframe_non_bool_dtype():
+    """An int-dtype DataFrame is rejected by the bool-dtype contract."""
+    graph = _canonical_digraph()
+    df = _canonical_dataframe().astype(int)
+
+    pre = HierarchicalPreprocessor(graph)
+    with pytest.raises(ValueError, match="bool-dtype"):
+        pre.fit(df)
+
+
+def test_digraph_with_integer_node_names():
+    """Integer-named DiGraph + DataFrame with matching string columns.
+
+    sklearn coerces DataFrame column labels to str in feature_names_in_, and
+    auto-derivation compares node names as strings, so str column "0" matches
+    integer node 0. This is the documented way to use an int-named DiGraph with
+    auto-derive.
+    """
+    graph = nx.DiGraph([(0, 1), (0, 2)])  # int node names
+    df = pd.DataFrame({"1": [True, False], "2": [False, True]}).astype(bool)
+
+    pre = HierarchicalPreprocessor(graph)
+    pre.fit(df)  # auto-derive via str(node) match
+    assert pre.is_fitted_
+    out = pre.transform(df)
+    # node 0 is the parent of both 1 and 2; a 1 in either child propagates to it
+    assert out.shape[0] == 2
+
+
+def test_digraph_with_string_node_names_dataframe_with_int_columns():
+    """String-named DiGraph but int-labelled DataFrame columns.
+
+    sklearn only records feature_names_in_ for all-string columns; integer
+    column labels are NOT captured, so auto-derive does not trigger and the
+    preprocessor falls back to positional 1:1 mapping (the same behaviour as
+    a plain ndarray X). The mismatch therefore surfaces as positional mapping
+    rather than name matching -- documented limitation: use string columns.
+    """
+    graph = nx.DiGraph([("dog", "cat")])
+    df = pd.DataFrame({0: [True, False], 1: [False, True]}).astype(bool)
+
+    pre = HierarchicalPreprocessor(graph)
+    assert not hasattr(pre, "feature_names_in_")
+    pre.fit(df)  # no feature names captured -> positional fallback, no raise
+    pre.fit(df)
+    assert pre.is_fitted_
+    assert not hasattr(pre, "feature_names_in_")
+
+
+# --- Round-trip / fit-transform consistency --------------------------------
+
+
+def test_dataframe_fit_dataframe_transform():
+    """fit on a DataFrame then transform on a DataFrame with the same columns."""
+    df = _canonical_dataframe()
+    graph = _canonical_digraph()
+
+    pre = HierarchicalPreprocessor(graph)
+    pre.fit(df)
+    # feature names are preserved through fit (single validate_data)
+    assert list(pre.feature_names_in_) == ["dog", "cat", "eagle"]
+
+    out = pre.transform(df)
+    assert np.array_equal(out.astype(int), _EXPECTED_CANONICAL)
+
+
+def test_dataframe_transform_mismatched_columns_raises():
+    """Transforming a DataFrame whose columns differ from fit raises ValueError."""
+    df = _canonical_dataframe()
+    graph = _canonical_digraph()
+
+    pre = HierarchicalPreprocessor(graph)
+    pre.fit(df)
+
+    df_wrong = df.rename(columns={"dog": "wolf"})
+    with pytest.raises(ValueError, match="feature names"):
+        pre.transform(df_wrong)
+
+
+def test_preprocessor_accepts_polars_dataframe_with_digraph():
+    """polars DataFrame works via sklearn's interchange-protocol plumbing.
+
+    scihfs imports no DataFrame library directly; polars support is inherited
+    from scikit-learn (feature names via __dataframe__, conversion via
+    np.asarray). Skipped when polars is not installed (no hard dependency).
+    """
+    pl = pytest.importorskip("polars")
+    _, _, _ = _canonical_setup()
+    graph = _canonical_digraph()
+    df = pl.DataFrame(
+        {
+            "dog": [True, False, False, True, False],
+            "cat": [False, True, False, False, False],
+            "eagle": [False, False, True, False, True],
+        }
+    )
+
+    pre = HierarchicalPreprocessor(graph)
+    pre.fit(df)
+    out = pre.transform(df)
+    out = out.toarray() if sp.issparse(out) else np.asarray(out)
+    assert np.array_equal(out.astype(int), _EXPECTED_CANONICAL)
+
+
+# --- get_feature_names_out / set_output ---------------------
+
+
+def test_get_feature_names_out_named_hierarchy():
+    """DiGraph hierarchy: names_out are the node names in _columns order."""
+    df = _canonical_dataframe()
+    graph = _canonical_digraph()
+
+    pre = HierarchicalPreprocessor(graph)
+    pre.fit(df)
+
+    names = pre.get_feature_names_out()
+    assert len(names) == len(pre._columns)
+    # data columns first, then the ancestor columns added during fit
+    assert list(names[:3]) == ["dog", "cat", "eagle"]
+    assert set(names) == {"dog", "cat", "eagle", "animal", "mammal", "bird"}
+
+
+def test_get_feature_names_out_unnamed_hierarchy():
+    """ndarray hierarchy: names_out are the ORIGINAL node indices (traceable).
+
+    dog/cat/eagle are original adjacency indices 4/5/6; the ancestor columns
+    added during fit are animal/mammal/bird = original indices 0/1/2. The names
+    must reflect those original indices, not the post-shrink renumbering.
+    """
+    X, hierarchy, columns = _canonical_setup()  # columns == [4, 5, 6]
+
+    pre = HierarchicalPreprocessor(hierarchy)
+    pre.fit(X, columns=columns)
+
+    names = pre.get_feature_names_out()
+    assert len(names) == len(pre._columns)
+    assert list(names[:3]) == ["4", "5", "6"]
+    assert set(names) == {"4", "5", "6", "0", "1", "2"}
+
+
+def test_get_feature_names_out_ndarray_matches_digraph_positions():
+    """ndarray index names line up position-for-position with DiGraph names."""
+    X, hierarchy, columns = _canonical_setup()
+    graph = _canonical_digraph()
+
+    pre_arr = HierarchicalPreprocessor(hierarchy)
+    pre_arr.fit(X, columns=columns)
+    pre_graph = HierarchicalPreprocessor(graph)
+    pre_graph.fit(_canonical_dataframe())
+
+    # Same column order; ndarray gives original indices, DiGraph gives names.
+    # index 4 <-> "dog", 5 <-> "cat", 6 <-> "eagle", 0 <-> "animal", ...
+    assert list(pre_arr.get_feature_names_out()) == ["4", "5", "6", "0", "1", "2"]
+    assert list(pre_graph.get_feature_names_out()) == [
+        "dog",
+        "cat",
+        "eagle",
+        "animal",
+        "mammal",
+        "bird",
+    ]
+
+
+def test_set_output_pandas():
+    """set_output('pandas') makes transform return a labelled DataFrame."""
+    df = _canonical_dataframe()
+    graph = _canonical_digraph()
+
+    pre = HierarchicalPreprocessor(graph)
+    pre.set_output(transform="pandas")
+    pre.fit(df)
+    out = pre.transform(df)
+
+    assert isinstance(out, pd.DataFrame)
+    assert list(out.columns) == list(pre.get_feature_names_out())
+    assert list(out.columns[:3]) == ["dog", "cat", "eagle"]
+    assert np.array_equal(out.to_numpy().astype(int), _EXPECTED_CANONICAL)
+
+
+def test_set_output_polars():
+    """set_output('polars') returns a labelled polars DataFrame (no extra code).
+
+    polars output is inherited from scikit-learn's registered PolarsAdapter;
+    scihfs imports no polars. Skipped when polars is not installed.
+    """
+    pl = pytest.importorskip("polars")
+    df = _canonical_dataframe()
+    graph = _canonical_digraph()
+
+    pre = HierarchicalPreprocessor(graph)
+    pre.set_output(transform="polars")
+    pre.fit(df)
+    out = pre.transform(df)
+
+    assert isinstance(out, pl.DataFrame)
+    assert out.columns == list(pre.get_feature_names_out())
+    assert out.columns[:3] == ["dog", "cat", "eagle"]
+    assert np.array_equal(out.to_numpy().astype(int), _EXPECTED_CANONICAL)
+
+
 def test_preprocessor_rejects_nan():
     """validate_data's ensure_all_finite check still rejects NaN.
 

--- a/scihfs/tests/test_preprocessing.py
+++ b/scihfs/tests/test_preprocessing.py
@@ -823,6 +823,41 @@ def test_orphan_ndarray_column_falls_back_to_x_node():
     assert any(n.startswith("x") for n in names)
 
 
+# --- Hierarchy validation error paths -------------------------------------
+
+
+def test_cyclic_hierarchy_raises_value_error():
+    """A hierarchy containing a cycle fails the DAG check in fit."""
+    # 0 -> 1 -> 2 -> 0 is a cycle, so no node has in-degree 0; the virtual
+    # ROOT connects nothing and the cycle survives -> not a DAG.
+    hierarchy = nx.to_numpy_array(nx.DiGraph([(0, 1), (1, 2), (2, 0)]))
+    X = np.zeros((2, 3), dtype=bool)
+
+    pre = HierarchicalPreprocessor(hierarchy)
+    with pytest.raises(ValueError, match="not a directed acyclic graph"):
+        pre.fit(X, columns=[0, 1, 2])
+
+
+def test_none_hierarchy_raises_type_error_in_fit():
+    """hierarchy=None reaches _set_hierarchy via the preprocessor and raises.
+
+    The preprocessor calls _fit_hierarchy directly (bypassing the base fit's
+    own None guard), so the None check inside _set_hierarchy is what fires.
+    """
+    X = np.zeros((2, 2), dtype=bool)
+    pre = HierarchicalPreprocessor(None)
+    with pytest.raises(TypeError, match="Hierarchy is None but is required"):
+        pre.fit(X)
+
+
+def test_invalid_hierarchy_type_raises_type_error():
+    """A hierarchy that is neither ndarray nor DiGraph raises TypeError."""
+    X = np.zeros((2, 2), dtype=bool)
+    pre = HierarchicalPreprocessor("not a graph")
+    with pytest.raises(TypeError, match="must be np.ndarray or nx.DiGraph"):
+        pre.fit(X)
+
+
 def test_dataframe_non_bool_dtype():
     """An int-dtype DataFrame is rejected by the bool-dtype contract."""
     graph = _canonical_digraph()

--- a/uv.lock
+++ b/uv.lock
@@ -2003,6 +2003,34 @@ wheels = [
 ]
 
 [[package]]
+name = "polars"
+version = "1.41.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/f9/aeda46259b0669247a160315d2d51269de9504b9dd2f70acadbcb22f46b7/polars-1.41.2.tar.gz", hash = "sha256:256d6731162371b77f3f29a55eacb8c0fc740ddb1a293a01d2ef5b5393c5c708", size = 737996, upload-time = "2026-05-29T17:39:15.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/22/28f62d24f7db56ac4343588f9362d49b7b4177e55ac47a466fe696b0099b/polars-1.41.2-py3-none-any.whl", hash = "sha256:23ce9a2910b6e3e8d4258770bf44aa17170958df7af6e85feedf4458a04d8d29", size = 833445, upload-time = "2026-05-29T17:37:05.576Z" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.41.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/56/54e3ea0e9b64f327179049e4742241cc6b1d3e8fa414b05a057dd26df367/polars_runtime_32-1.41.2.tar.gz", hash = "sha256:7af09ec1ab053da2c9669e8d15f809a4083a29be05db57111688b8051062af56", size = 2989474, upload-time = "2026-05-29T17:39:17.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/9b/fe72a3811c0357cdb06c67bdc7695fa1623ad47948fc523195f5ac31037f/polars_runtime_32-1.41.2-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:95a08346dac337357cdb825c8076df7d36da54c4caa59a5cb41d0a30691c5edd", size = 52265283, upload-time = "2026-05-29T17:37:09.407Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/93/fab9da803fd80d9e83ef88c20932f637a10bc611b20415fc322eec84bc44/polars_runtime_32-1.41.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:dedfaeec2c7f995298da7319dd9431d662e5dd1d0ec51b1459df4a0234ceff52", size = 46571222, upload-time = "2026-05-29T17:37:13.698Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/2a/8843f34a8ac57acd058a39b87b03b580dd352a490e9dae0415e02033bdd4/polars_runtime_32-1.41.2-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:18eea22c5cc34e27f8a60950458ad81e6a9ea75e89363ca1367e14e7e7f781fc", size = 50409372, upload-time = "2026-05-29T17:37:17.875Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c6/92b352fe88cf51bd0a19fb99e1c0cbe46aa26c14dcf7995b89869cd932ae/polars_runtime_32-1.41.2-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2630540dfdfb0f36f9b04a07c7c2e3f50bf2ad384113263c1c812007ee9141e0", size = 56405484, upload-time = "2026-05-29T17:37:22.684Z" },
+    { url = "https://files.pythonhosted.org/packages/74/c4/bae3174c3b02f6b441d2e58594387abcd509f67a098f682a83b195f08966/polars_runtime_32-1.41.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:20e969e08f9b137e233c04cc04de73d9795f89eb77d34854e40a025965a43763", size = 50603512, upload-time = "2026-05-29T17:37:27.422Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ed/f2d26ae02d92c2689056838ed59e2a626326ad23c2831d58637d25f6c82a/polars_runtime_32-1.41.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e7016a3deb641b64a31447abbbee0f34bd020a6a9ae34ee6b743837def15e2a4", size = 54328561, upload-time = "2026-05-29T17:37:32.587Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/c4/9c3831cc885dc7769e59abf8f583821a5fb4403fd0e4eba0ccc6d47a3d4b/polars_runtime_32-1.41.2-cp310-abi3-win_amd64.whl", hash = "sha256:1e5e5377c315e0dcafdfb2a31adc546abbaeb3f9cb1864e6536523d2af473265", size = 51978643, upload-time = "2026-05-29T17:37:37.443Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c6/79e9f3f270270d7ed5575d92b7bfef49f01abd9275447161275b23b553a8/polars_runtime_32-1.41.2-cp310-abi3-win_arm64.whl", hash = "sha256:843d96f69d18eca53429c1198e58891db7f18111f83b9c419bb45ad9d73eaed5", size = 46006901, upload-time = "2026-05-29T17:37:42.522Z" },
+]
+
+[[package]]
 name = "pre-commit"
 version = "4.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2434,6 +2462,7 @@ dev = [
     { name = "matplotlib" },
     { name = "mypy" },
     { name = "numpydoc" },
+    { name = "polars" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -2464,6 +2493,7 @@ dev = [
     { name = "matplotlib", specifier = ">=3.8.2,<4" },
     { name = "mypy", specifier = ">=1.13.0,<2" },
     { name = "numpydoc", specifier = ">=1.6.0,<2" },
+    { name = "polars", specifier = ">=1.0,<2" },
     { name = "pre-commit", specifier = ">=4.0.1,<5" },
     { name = "pytest", specifier = ">=7.4.4,<8" },
     { name = "pytest-cov", specifier = ">=6.0.0,<7" },


### PR DESCRIPTION
Added DataFrame support to the **HierarchicalPreprocessor** class.

Specifically:
- The class now accepts DataFrame input which is internally handled by sklearn's validate_data initially, yielding `feature_names_in_`.
- With this attribute set, the column --> node mapping can now automatically be derived from the input.\*
- The node identifier (name or column index) is set as node attribute of the internal nx.DiGraph object. Orphan columns in the dataframe (which are not in the hierarchy) get their own feature name.
- That information is retrieved in the newly implemented `get_feature_names_out` function, which provides the basis for sklearn's set_output API (returning a labelled pandas or polars DataFrame – labels as either node indices or node names depending on input).
- (Also removed the duplicate validate_data call in fit(), which deleted the feature_names_in_ in the second pass.)

\* To use this feature, the hierarchy must be passed as a named nx.DiGraph where its node keys match the DataFrame column names.

Also added corresponding example and tests (LLM-generated, manually validated), which now include polars as additional dev dependency.

The legacy way of input has been preserved – `X: ndarray`, `hierarchy: ndarray`, `columns: list[int]` – but the workflow has now been significantly simplified with the new approach.

Important future work includes dedicated DataFrame support for Selectors.

Closes #106 #107 #108.