### PR TITLE
Eliminated O(n^2) loops, added tests

### DIFF
--- a/scihfs/helpers.py
+++ b/scihfs/helpers.py
@@ -128,79 +128,45 @@ def get_leaves(graph: nx.DiGraph):
     return leaves
 
 
-def shrink_dag(node_identifiers: list, digraph: nx.DiGraph):
-    """Remove irrelevant leaf nodes from the given DAG.
+def shrink_dag(relevant_nodes: list, digraph: nx.DiGraph):
+    """Remove nodes that cannot reach any relevant node identifier.
+
+    A node is kept iff it is itself a node from the ``relevant_nodes`` list, an
+    ancestor of one, or the virtual ``"ROOT"``. Every other node is a dead
+    branch of the ontology (no corresponding data column and no descendant
+    that has one) and is removed.
 
     Parameters
     ----------
-    node_identifiers : list
+    relevant_nodes : list
             A list containing node identifiers that are considered relevant
     digraph : networkx.DiGraph
-            The Directed Acyclic Graph (DAG) from which irrelevant leaf nodes
+            The Directed Acyclic Graph (DAG) from which dead-branch nodes
             will be removed.
 
     Returns
     ----------
     digraph : networkx.DiGraph
-            The resulting DAG after removing all irrelevant leaf nodes.
-    """
-    to_remove = {
-        node
-        for node in digraph.nodes()
-        if _is_irrelevant_leaf(node, node_identifiers, digraph)
-    }
+            The resulting DAG after removing all dead-branch nodes.
 
-    while to_remove:
-        # Recompute the list of nodes to check (predecessors of removed nodes)
-        to_check = {
-            predecessor
-            for node in to_remove
-            for predecessor in digraph.predecessors(node)
-        }
-        digraph.remove_nodes_from(to_remove)
-        to_remove = {
-            node
-            for node in to_check
-            if _is_irrelevant_leaf(node, node_identifiers, digraph)
-        }
+    Notes
+    -----
+    Currently still mutating ``digraph`` in place AND returning it. Temporarily kept here for backward compatibility; will be addressed in the near future.
+    """
+    useful = set(relevant_nodes) | {"ROOT"}
+    for node in relevant_nodes:
+        useful |= nx.ancestors(digraph, node)
+    digraph.remove_nodes_from(set(digraph.nodes()) - useful)
     return digraph
 
 
-def _is_irrelevant_leaf(node, node_identifiers, digraph):
+def connect_dag(relevant_nodes: list, hierarchy: nx.DiGraph):
     """
-    Determine if a node is an irrelevant leaf in a directed acyclic graph (DAG).
-
-    A node is considered an irrelevant leaf if:
-    - It has no outgoing edges (i.e., it is a leaf node).
-    - It is not included in the specified list of relevant node identifiers.
-    - It is not the "ROOT" node
+    Connects digraph (DAG), so that every node not in relevant_nodes is removed from the DAG, and an new edge with its predecessor is built.
 
     Parameters
     ----------
-    node : Any
-        The node to evaluate.
-    node_identifiers : list
-        A list of node identifiers that are considered relevant and should not be removed.
-    digraph : networkx.DiGraph
-        The directed acyclic graph (DAG) being analyzed.
-
-    Returns
-    ----------
-    bool
-        True if the node is an irrelevant leaf; otherwise, False.
-    """
-    return (
-        digraph.out_degree(node) == 0 and node != "ROOT" and node not in node_identifiers
-    )
-
-
-def connect_dag(node_identifiers: list, hierarchy: nx.DiGraph):
-    """
-    Connects digraph (DAG), so that every node not in node_identifiers is removed from the DAG, and an new edge with its predecessor is built.
-
-    Parameters
-    ----------
-    node_identifiers: list
+    relevant_nodes: list
                 A list of node identifiers that are considered relevant and should not be removed.
     hierarchy : networkx.DiGraph
                 The Directed Acyclic Graph (DAG) representing the hierarchy.
@@ -221,15 +187,15 @@ def connect_dag(node_identifiers: list, hierarchy: nx.DiGraph):
         predecessors = list(hierarchy.predecessors(node))
         for predecessor in predecessors:
             new_connections = []
-            if predecessor not in node_identifiers:
+            if predecessor not in relevant_nodes:
                 for pred_of_pred in hierarchy.predecessors(predecessor):
                     new_connections.append(pred_of_pred)
                 for new_connection in new_connections:
                     hierarchy.add_edge(new_connection, node)
 
-    # remove all nodes (and edges) that are not in node_identifier
+    # remove all nodes (and edges) that are not in relevant_nodes
     nodes_to_remove = [
-        node for node in hierarchy.nodes if node not in set(node_identifiers)
+        node for node in hierarchy.nodes if node not in set(relevant_nodes)
     ]
     hierarchy.remove_nodes_from(nodes_to_remove)
     return hierarchy

--- a/scihfs/preprocessing.py
+++ b/scihfs/preprocessing.py
@@ -315,20 +315,21 @@ class HierarchicalPreprocessor(HierarchicalEstimator):
         features would always be 0 in the dataset and, therefore, do not
         contain any necessary information.
         """
-        node_identifier = self._columns
+        relevant_nodes = self._columns
         digraph = self._hierarchy_graph
-        self._hierarchy_graph = shrink_dag(node_identifier, digraph)
+        self._hierarchy_graph = shrink_dag(relevant_nodes, digraph)
 
     def _find_missing_columns(self):
         """Finds nodes for which a column needs to be added to the dataset.
 
         These node names are added to self._columns and the corresponding
-        columns will be added in the transform method.
+        columns will be added in the transform method. Typical use cases are disconnected hierarchies or (flat) features from outside the hierarchy.
         """
+        columns_set = set(self._columns)
         missing_nodes = [
             node
             for node in self._hierarchy_graph.nodes
-            if node not in self._columns and node != "ROOT"
+            if node not in columns_set and node != "ROOT"
         ]
         self._columns.extend(missing_nodes)
 
@@ -424,6 +425,6 @@ class HierarchicalPreprocessor(HierarchicalEstimator):
         """
         nodes = list(self._hierarchy_graph.nodes())
         nodes.remove("ROOT")
-        self._columns = [nodes.index(node_name) for node_name in self._columns]
-        mapping = {node_name: nodes.index(node_name) for node_name in nodes}
-        self._hierarchy_graph = nx.relabel_nodes(self._hierarchy_graph, mapping)
+        position_lookup = {node_name: i for i, node_name in enumerate(nodes)}
+        self._columns = [position_lookup[node_name] for node_name in self._columns]
+        self._hierarchy_graph = nx.relabel_nodes(self._hierarchy_graph, position_lookup)

--- a/scihfs/tests/test_helpers.py
+++ b/scihfs/tests/test_helpers.py
@@ -18,20 +18,75 @@ from scihfs.metrics import gain_ratio, information_gain
 def test_shrink_dag():
     edges = [(0, 1), (0, 2), (0, 4), (3, 4), (3, 5), (6, 1), (6, 4)]
     graph = nx.DiGraph(edges)
-    node_identifiers = [1]
+    relevant_nodes = [1]
     nodes_to_remove = [2, 3, 4, 5]
 
     assert len(graph.nodes()) == 7
-    graph = shrink_dag(node_identifiers, graph)
+    graph = shrink_dag(relevant_nodes, graph)
     assert len(graph.nodes()) == 3
     assert all(node not in graph.nodes() for node in nodes_to_remove)
+
+
+# ---------------------------------------------------------------------------
+# shrink_dag: edge cases (permanent) pinning the new ancestor-walk behaviour.
+# ---------------------------------------------------------------------------
+
+
+def _rooted_dag(edges):
+    """Build a DiGraph from edges and attach the virtual ROOT above sources."""
+    return add_virtual_root_node(nx.DiGraph(edges))
+
+
+def test_shrink_dag_in_place_mutation_and_return_identity():
+    """shrink_dag mutates its input AND returns the same object. This behaviour will be removed in the future."""
+    graph = _rooted_dag([(0, 1), (0, 2)])
+    result = shrink_dag([1], graph)
+    assert result is graph
+    assert 2 not in graph.nodes()
+
+
+def test_shrink_dag_empty_identifiers_keeps_root_only():
+    """No relevant identifiers: every real node is a dead branch; ROOT survives."""
+    graph = _rooted_dag([(0, 1), (0, 2), (1, 3)])
+    shrink_dag([], graph)
+    assert set(graph.nodes()) == {"ROOT"}
+
+
+def test_shrink_dag_all_nodes_identifiers_prunes_nothing():
+    """Every node is relevant: output equals input (no node removed)."""
+    graph = _rooted_dag([(0, 1), (0, 2), (1, 3)])
+    before = set(graph.nodes())
+    shrink_dag([0, 1, 2, 3], graph)
+    assert set(graph.nodes()) == before
+
+
+def test_shrink_dag_single_root_only_passthrough():
+    """A graph that is just ROOT passes through untouched."""
+    graph = nx.DiGraph()
+    graph.add_node("ROOT")
+    shrink_dag([], graph)
+    assert set(graph.nodes()) == {"ROOT"}
+
+
+def test_shrink_dag_keeps_interior_identifier_and_its_subtree_ancestors():
+    """An interior (non-leaf) relevant node survives along with all its ancestors.
+
+    nx.ancestors excludes the node itself, so the union with relevant_nodes
+    is what keeps the node when it happens to be a leaf; here we also
+    confirm an interior relevant node keeps its ancestor chain up to ROOT.
+    """
+    graph = _rooted_dag([(0, 1), (1, 2), (1, 3), (0, 4)])
+    shrink_dag([1], graph)
+    # 1 (relevant) + 0 (ancestor) + ROOT survive; 2, 3 (descendants) and the
+    # unrelated branch 4 are pruned.
+    assert set(graph.nodes()) == {"ROOT", 0, 1}
 
 
 def test_connect_dag(lazy_data4):
     small_DAG, big_DAG = lazy_data4
     graph = nx.DiGraph(big_DAG)
-    node_identifiers = [0, 1, 2, 5, 6, 7, 8]
-    graph = connect_dag(hierarchy=graph, node_identifiers=node_identifiers)
+    relevant_nodes = [0, 1, 2, 5, 6, 7, 8]
+    graph = connect_dag(hierarchy=graph, relevant_nodes=relevant_nodes)
     new_graph = nx.DiGraph([(0, 1), (0, 2), (1, 6), (1, 5), (1, 7), (0, 7), (5, 8)])
     assert nx.is_isomorphic(graph, new_graph)
 

--- a/scihfs/tests/test_preprocessing.py
+++ b/scihfs/tests/test_preprocessing.py
@@ -1071,3 +1071,64 @@ def test_preprocessor_rejects_nan():
     pre = HierarchicalPreprocessor(hierarchy)
     with pytest.raises(ValueError):
         pre.fit(X, columns=columns)
+
+
+# ---------------------------------------------------------------------------
+# _find_missing_columns / _adjust_node_names edge cases (permanent) and
+# node-attribute survival across shrink + relabel.
+# ---------------------------------------------------------------------------
+
+
+def _bare_preprocessor(columns, hierarchy_graph):
+    """Construct an unfitted preprocessor with the two attributes the
+    fit-path helpers read/write, so they can be exercised in isolation."""
+    pre = HierarchicalPreprocessor(None)
+    pre._columns = columns
+    pre._hierarchy_graph = hierarchy_graph
+    return pre
+
+
+def test_find_missing_columns_empty_columns_adds_all_non_root():
+    graph = nx.DiGraph([("ROOT", "a"), ("a", "b"), ("a", "c")])
+    pre = _bare_preprocessor([], graph)
+    pre._find_missing_columns()
+    assert pre._columns == ["a", "b", "c"]  # graph node order, ROOT excluded
+
+
+def test_find_missing_columns_superset_columns_unchanged():
+    graph = nx.DiGraph([("ROOT", "a"), ("a", "b")])
+    columns = ["a", "b", "extra"]  # already a superset of the graph's real nodes
+    pre = _bare_preprocessor(list(columns), graph)
+    pre._find_missing_columns()
+    assert pre._columns == columns  # nothing to add
+
+
+def test_adjust_node_names_root_and_single_node():
+    graph = nx.DiGraph([("ROOT", "a")])
+    pre = _bare_preprocessor(["a"], graph)
+    pre._adjust_node_names()
+    assert pre._columns == [0]
+    assert set(pre._hierarchy_graph.nodes()) == {"ROOT", 0}
+
+
+def test_node_attributes_survive_shrink_and_relabel():
+    """Every surviving node keeps ORIGINAL_NODE_IDENTIFIER through the full fit.
+
+    Uses the canonical DiGraph + DataFrame: fish/trout are a dead branch
+    (pruned by _shrink_dag) and animal/mammal/bird are missing ancestors
+    (added by _extend_dag/_find_missing_columns), so all three rewrites run.
+    get_feature_names_out / set_output rely on this attribute surviving the
+    prune + relabel.
+    """
+    from scihfs.selectors.base import ORIGINAL_NODE_IDENTIFIER
+
+    df = _canonical_dataframe()
+    graph = _canonical_digraph()
+
+    pre = HierarchicalPreprocessor(graph)
+    pre.fit(df)
+
+    for node, data in pre._hierarchy_graph.nodes(data=True):
+        if node == "ROOT":
+            continue
+        assert ORIGINAL_NODE_IDENTIFIER in data, f"node {node} lost its attribute"


### PR DESCRIPTION
Eliminated a few $O(n^2)$ loops in the preprocessing and its helper functions. Added corresponding tests covering the changed functions (LLM-generated, manually validated). Also changed one variable name to be more expressive (`node_identifiers` to `relevant_nodes`).