### PR TITLE
Fixed hierarchy export and added sparse support

### DIFF
--- a/doc/preprocessing.rst
+++ b/doc/preprocessing.rst
@@ -71,7 +71,7 @@ The following function demonstrates how to use `HierarchicalPreprocessor` to pre
        preprocessor.fit(X_train, columns=columns)
        X_train_transformed = preprocessor.transform(X_train)
        X_test_transformed = preprocessor.transform(X_test)
-       hierarchy_updated = preprocessor.get_hierarchy()
+       hierarchy_updated = preprocessor.to_adjacency_matrix()
        columns_updated = preprocessor.get_columns()
        return X_train_transformed, X_test_transformed, hierarchy_updated, columns_updated
 

--- a/examples/lazy_learning_example.py
+++ b/examples/lazy_learning_example.py
@@ -36,7 +36,7 @@ def preprocess():
     # requires integer-valued samples; cast back to int after preprocessing.
     train = preprocessor.transform(train_x_data).astype(int)
     test = preprocessor.transform(test_x_data).astype(int)
-    hierarchy = preprocessor.get_hierarchy()
+    hierarchy = preprocessor.to_adjacency_matrix()
     return (train, test, train_y_data, test_y_data, hierarchy)
 
 

--- a/scihfs/preprocessing.py
+++ b/scihfs/preprocessing.py
@@ -79,8 +79,8 @@ class HierarchicalPreprocessor(HierarchicalEstimator):
         method.
 
         After fitting, the dataset can be transformed with the `transform` method, and
-        the updated hierarchy and column mapping can be retrieved with `get_hierarchy`
-        and `get_columns`.
+        the updated hierarchy and column mapping can be retrieved with the
+        `to_adjacency_matrix` method and `get_columns`.
 
         Parameters
         ----------
@@ -212,21 +212,46 @@ class HierarchicalPreprocessor(HierarchicalEstimator):
         X_ = self._propagate_ones(X_)
         return X_
 
-    def get_hierarchy(self):
-        """Get the transformed hierarchy graph.
+    def to_adjacency_matrix(self, sparse=False):
+        """Return the hierarchy as an adjacency matrix (after fit).
+
+        Computed from ``self._hierarchy_graph`` (which remains the immutable
+        single source of truth) on each call, with the synthetic ``"ROOT"`` node excluded.
+
+        Parameters
+        ----------
+        sparse : bool, default=False
+            If ``True``, return a ``scipy.sparse`` CSR array; if ``False``,
+            return a dense ``np.ndarray``. Both encode the same matrix with the
+            same node ordering, so ``result.toarray()`` of the sparse form
+            equals its equivalent for the dense form.
+
+            .. note::
+                The sensible way to use this function is with `sparse=True`.
+                However at the moment, the default is ``False`` (dense) because the selectors do
+                not yet accept a sparse hierarchy. This behaviour is expected to flip
+                to ``True`` once selector-side sparse support will be implemented.
+
+        Returns
+        -------
+        np.ndarray or scipy.sparse.csr_array
+            The transformed hierarchy as an adjacency matrix -- dense when
+            ``sparse=False``, CSR when ``sparse=True``.
 
         Raises
-        ----------
-        RuntimeError
-            If the method is called before fit has been called.
-            In this case the hierarchy graph has not been updated yet.
+        ------
+        NotFittedError
+            If called before ``fit`` has been called.
         """
-        if self.is_fitted_:
-            output_hierarchy = self._hierarchy_graph
-            output_hierarchy.remove_node("ROOT")
-            return nx.to_numpy_array(self._hierarchy_graph)
-        else:
-            raise RuntimeError("Instance has not been fitted.")
+        check_is_fitted(self, "is_fitted_")
+        # Copy before removing ROOT so the canonical graph is never mutated.
+        # The copy is load-bearing: without it this would mutate
+        # _hierarchy_graph and only be callable once.
+        graph_view = self._hierarchy_graph.copy()
+        graph_view.remove_node("ROOT")
+        if sparse:
+            return nx.to_scipy_sparse_array(graph_view, format="csr")
+        return nx.to_numpy_array(graph_view)
 
     def get_feature_names_out(self, input_features=None):
         """Map each output column to its hierarchy node name.

--- a/scihfs/tests/test_preprocessing.py
+++ b/scihfs/tests/test_preprocessing.py
@@ -26,7 +26,7 @@ def test_hierarchical_preprocessor(data, request):
     assert preprocessor.is_fitted_
     X = preprocessor.transform(X)
     assert np.array_equal(X, X_transformed)
-    hierarchy_transformed = preprocessor.get_hierarchy()
+    hierarchy_transformed = preprocessor.to_adjacency_matrix()
     assert np.array_equal(hierarchy_transformed, hierarchy_expected)
 
 
@@ -35,7 +35,7 @@ def test_fit(data3_preprocessing):
     preprocessor = HierarchicalPreprocessor(hierarchy)
     preprocessor.fit(X.astype(bool), columns=X_identifiers)
     assert preprocessor.is_fitted_
-    hierarchy = preprocessor.get_hierarchy()
+    hierarchy = preprocessor.to_adjacency_matrix()
     assert np.equal(hierarchy.all(), hierarchy_transformed.all())
 
 
@@ -1132,3 +1132,102 @@ def test_node_attributes_survive_shrink_and_relabel():
         if node == "ROOT":
             continue
         assert ORIGINAL_NODE_IDENTIFIER in data, f"node {node} lost its attribute"
+
+
+# ---------------------------------------------------------------------------
+# to_adjacency_matrix(): idempotency, non-mutation, fit-gating, and the sklearn
+# clone() round-trip that pins the user-input-preservation contract.
+# ---------------------------------------------------------------------------
+
+
+def _fitted_canonical_preprocessor():
+    """A HierarchicalPreprocessor fitted on the canonical DiGraph + DataFrame."""
+    pre = HierarchicalPreprocessor(_canonical_digraph())
+    pre.fit(_canonical_dataframe())
+    return pre
+
+
+def test_to_adjacency_matrix_idempotent():
+    """Repeated calls return equal arrays and leave ROOT in the graph."""
+    pre = _fitted_canonical_preprocessor()
+
+    first = pre.to_adjacency_matrix()
+    second = pre.to_adjacency_matrix()
+    third = pre.to_adjacency_matrix()
+
+    assert np.array_equal(first, second)
+    assert np.array_equal(second, third)
+    # The synthetic ROOT must survive every call.
+    assert "ROOT" in pre._hierarchy_graph.nodes
+
+
+def test_to_adjacency_matrix_does_not_mutate_underlying_graph():
+    """The canonical graph is byte-for-byte identical after a call."""
+    pre = _fitted_canonical_preprocessor()
+
+    nodes_before = set(pre._hierarchy_graph.nodes)
+    edges_before = set(pre._hierarchy_graph.edges)
+    attrs_before = {
+        node: dict(data) for node, data in pre._hierarchy_graph.nodes(data=True)
+    }
+
+    _ = pre.to_adjacency_matrix()
+
+    assert set(pre._hierarchy_graph.nodes) == nodes_before
+    assert set(pre._hierarchy_graph.edges) == edges_before
+    attrs_after = {
+        node: dict(data) for node, data in pre._hierarchy_graph.nodes(data=True)
+    }
+    assert attrs_after == attrs_before
+
+
+def test_to_adjacency_matrix_raises_before_fit():
+    """Calling to_adjacency_matrix() before fit raises NotFittedError."""
+    from sklearn.exceptions import NotFittedError
+
+    pre = HierarchicalPreprocessor(_canonical_digraph())
+    with pytest.raises(NotFittedError):
+        pre.to_adjacency_matrix()
+
+
+def test_to_adjacency_matrix_sparse_matches_dense():
+    """sparse=True returns a scipy CSR array equal to the dense default."""
+    pre = _fitted_canonical_preprocessor()
+
+    dense = pre.to_adjacency_matrix()  # default
+    spar = pre.to_adjacency_matrix(sparse=True)
+
+    assert isinstance(dense, np.ndarray)  # default is dense
+    assert sp.issparse(spar)
+    assert np.array_equal(spar.toarray(), dense)
+
+
+def test_clone_preserves_ndarray_hierarchy_input():
+    """clone() round-trips an ndarray hierarchy without fit-time state."""
+    from sklearn.base import clone
+
+    hierarchy = nx.to_numpy_array(nx.DiGraph([(0, 1), (0, 2), (1, 3)]))
+    pre = HierarchicalPreprocessor(hierarchy=hierarchy)
+
+    cloned = clone(pre)
+
+    assert isinstance(cloned.hierarchy, np.ndarray)
+    assert np.array_equal(cloned.hierarchy, hierarchy)
+    assert not hasattr(cloned, "_hierarchy_graph")
+    assert not hasattr(cloned, "is_fitted_")
+
+
+def test_clone_preserves_digraph_hierarchy_input():
+    """clone() round-trips a DiGraph hierarchy without fit-time state."""
+    from sklearn.base import clone
+
+    hierarchy = _canonical_digraph()
+    pre = HierarchicalPreprocessor(hierarchy=hierarchy)
+
+    cloned = clone(pre)
+
+    assert isinstance(cloned.hierarchy, nx.DiGraph)
+    assert set(cloned.hierarchy.nodes) == set(hierarchy.nodes)
+    assert set(cloned.hierarchy.edges) == set(hierarchy.edges)
+    assert not hasattr(cloned, "_hierarchy_graph")
+    assert not hasattr(cloned, "is_fitted_")


### PR DESCRIPTION
Addressed a design flaw mutating the hierarchy digraph (`_hierarchy_graph` variable) when exporting the hierarchy after HierarchicalPreprocessor's *fit*. Also added a `sparse` option (CSR format) for that export – which could be picked up by future changes to the Selector class.

The name has been changed from `get_hierarchy()` to `to_adjacency_matrix()` to reflect that this operation does not simply return a view, but initializes a non-cheap new object plus computation.

Added corresponding tests (LLM-generated, manually validated).

Closes #111.