### PR TITLE
Preprocessor mvp final touches

### DIFF
--- a/scihfs/helpers.py
+++ b/scihfs/helpers.py
@@ -67,6 +67,30 @@ def check_bool_dtype(X):
         )
 
 
+def _check_unique_column_mappings(columns):
+    """Raise ValueError if any non-(-1) value appears more than once in columns.
+
+    The ``columns`` variable is a list of integers doing the column->node mapping and can be supplied
+    directly by the user or be auto-derived from the DataFrame feature names.
+    Two equal non-(-1) entries mean two data columns map to the same hierarchy node, which is ill-defined (the orphan column marker -1 is exempt and may repeat).
+    The values reported on failure are node positions (not DataFrame column names).
+    """
+    seen, duplicates = set(), set()
+    for c in columns:
+        if c == -1:
+            continue
+        (duplicates if c in seen else seen).add(c)
+    if duplicates:
+        raise ValueError(
+            f"Duplicate column->node mappings detected: {sorted(duplicates)}. "
+            f"Each entry in `columns` (except for the orphan column marker -1) "
+            f"must map a data column to a unique hierarchy node."
+            f"Suggested solution: If X was a DataFrame, check it for duplicate column names with "
+            f"df.columns[df.columns.duplicated()]. "
+            f"prior to feeding the dataset to the Estimator."
+        )
+
+
 def check_data(dag, x_data, y_data):
     """Checks whether the given dataset satisfies the 0-1-propagation on the DAG.
 

--- a/scihfs/helpers.py
+++ b/scihfs/helpers.py
@@ -160,47 +160,6 @@ def shrink_dag(relevant_nodes: list, digraph: nx.DiGraph):
     return digraph
 
 
-def connect_dag(relevant_nodes: list, hierarchy: nx.DiGraph):
-    """
-    Connects digraph (DAG), so that every node not in relevant_nodes is removed from the DAG, and an new edge with its predecessor is built.
-
-    Parameters
-    ----------
-    relevant_nodes: list
-                A list of node identifiers that are considered relevant and should not be removed.
-    hierarchy : networkx.DiGraph
-                The Directed Acyclic Graph (DAG) representing the hierarchy.
-
-    """
-    top_sort = nx.topological_sort(hierarchy)
-
-    # node i = 0: source is either in or not in, as there are no predecessors,
-    # there should not be any artificial edge
-    # i: for each pred there is a direct edge to the pred and iff pred not in x_ide
-    #       also to their pred2. (it does not matter if pred2 is really in x, if it is not,
-    #       the edge will be removed later anyway)
-    # i+1: if i is in -> no artificial edge on this path needed
-    #       if i is not -> artifical edge to every pred of i, so each path going through i
-    #       will be continued, if i is removed later
-
-    for node in list(top_sort):
-        predecessors = list(hierarchy.predecessors(node))
-        for predecessor in predecessors:
-            new_connections = []
-            if predecessor not in relevant_nodes:
-                for pred_of_pred in hierarchy.predecessors(predecessor):
-                    new_connections.append(pred_of_pred)
-                for new_connection in new_connections:
-                    hierarchy.add_edge(new_connection, node)
-
-    # remove all nodes (and edges) that are not in relevant_nodes
-    nodes_to_remove = [
-        node for node in hierarchy.nodes if node not in set(relevant_nodes)
-    ]
-    hierarchy.remove_nodes_from(nodes_to_remove)
-    return hierarchy
-
-
 def add_virtual_root_node(hierarchy: nx.DiGraph):
     """Create a virtual root node to connect disjoint hierarchies.
 

--- a/scihfs/selectors/base.py
+++ b/scihfs/selectors/base.py
@@ -7,7 +7,7 @@ import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted, validate_data
 
-from scihfs.helpers import add_virtual_root_node
+from scihfs.helpers import _check_unique_column_mappings, add_virtual_root_node
 
 # Node-attribute key for recording a node's original identity (name or index) in the hierarchy graph. Left untouched by all operations on the graph.
 # Consumed by get_feature_names_out to map back to original node names / indexes.
@@ -94,6 +94,10 @@ class HierarchicalEstimator(TransformerMixin, BaseEstimator):
             self._columns = columns
         else:
             self._columns = list(range(self.n_features_in_))
+
+        # Check whether there are duplicate column mappings (not dependent of the input route).
+        # Placed at this point because unique column<->node mappings are required for the downstream processing and no such validation has been performed yet (specifically not in sklearn.utils.validation.validate_data).
+        _check_unique_column_mappings(self._columns)
 
         self._set_hierarchy()
         self._check_dag()

--- a/scihfs/tests/test_helpers.py
+++ b/scihfs/tests/test_helpers.py
@@ -8,7 +8,6 @@ from info_gain.info_gain import info_gain, info_gain_ratio
 from scihfs.helpers import (
     add_virtual_root_node,
     compute_aggregated_values,
-    connect_dag,
     get_relevance,
     shrink_dag,
 )
@@ -80,15 +79,6 @@ def test_shrink_dag_keeps_interior_identifier_and_its_subtree_ancestors():
     # 1 (relevant) + 0 (ancestor) + ROOT survive; 2, 3 (descendants) and the
     # unrelated branch 4 are pruned.
     assert set(graph.nodes()) == {"ROOT", 0, 1}
-
-
-def test_connect_dag(lazy_data4):
-    small_DAG, big_DAG = lazy_data4
-    graph = nx.DiGraph(big_DAG)
-    relevant_nodes = [0, 1, 2, 5, 6, 7, 8]
-    graph = connect_dag(hierarchy=graph, relevant_nodes=relevant_nodes)
-    new_graph = nx.DiGraph([(0, 1), (0, 2), (1, 6), (1, 5), (1, 7), (0, 7), (5, 8)])
-    assert nx.is_isomorphic(graph, new_graph)
 
 
 def test_relevance(lazy_data2):

--- a/scihfs/tests/test_preprocessing.py
+++ b/scihfs/tests/test_preprocessing.py
@@ -1231,3 +1231,101 @@ def test_clone_preserves_digraph_hierarchy_input():
     assert set(cloned.hierarchy.edges) == set(hierarchy.edges)
     assert not hasattr(cloned, "_hierarchy_graph")
     assert not hasattr(cloned, "is_fitted_")
+
+
+# ---------------------------------------------------------------------------
+# `columns` uniqueness validation. Two data columns mapping to
+# the same hierarchy node is semantically ill-defined and rejected at fit;
+# -1 (orphan) markers are exempt, including when repeated.
+# ---------------------------------------------------------------------------
+
+
+def _six_column_setup():
+    """Bool X with 6 columns and a 6-node adjacency hierarchy (indices 0..5)."""
+    graph = nx.DiGraph([(0, 1), (0, 2), (1, 3), (1, 4), (2, 5)])
+    hierarchy = nx.to_numpy_array(graph)
+    X = np.array(
+        [
+            [1, 0, 0, 1, 0, 0],
+            [0, 1, 0, 0, 1, 0],
+            [0, 0, 1, 0, 0, 1],
+            [1, 1, 0, 0, 0, 0],
+            [0, 0, 0, 1, 0, 1],
+        ],
+        dtype=bool,
+    )
+    return X, hierarchy
+
+
+def test_fit_rejects_duplicate_columns_manual():
+    """Two non-(-1) entries mapping to the same node are rejected."""
+    X, hierarchy = _six_column_setup()
+    pre = HierarchicalPreprocessor(hierarchy)
+    with pytest.raises(ValueError, match="Duplicate"):
+        pre.fit(X, columns=[0, 0, 1, 2, 3, 4])
+
+
+def test_fit_allows_multiple_orphan_columns():
+    """Multiple -1 entries are legitimate; each mints a fresh node downstream."""
+    X, hierarchy = _six_column_setup()
+    pre = HierarchicalPreprocessor(hierarchy)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", ColumnNotInHierarchyWarning)
+        pre.fit(X, columns=[-1, -1, 1, 2, 3, 4])
+    assert pre.is_fitted_
+
+
+def test_fit_allows_single_orphan():
+    """A single -1 orphan succeeds (regression guard on the existing path)."""
+    X, hierarchy = _six_column_setup()
+    pre = HierarchicalPreprocessor(hierarchy)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", ColumnNotInHierarchyWarning)
+        pre.fit(X, columns=[-1, 1, 2, 3, 4, 5])
+    assert pre.is_fitted_
+
+
+def test_fit_rejects_duplicate_columns_with_orphans():
+    """A -1 entry does not suppress duplicate detection among non-(-1) values."""
+    X, hierarchy = _six_column_setup()
+    pre = HierarchicalPreprocessor(hierarchy)
+    with pytest.raises(ValueError, match="Duplicate"):
+        pre.fit(X, columns=[-1, 0, 0, 2, 3, 4])
+
+
+def test_fit_dataframe_autoderive_path_unaffected():
+    """The DataFrame auto-derive path still fits (names are unique)."""
+    df = _canonical_dataframe()
+    graph = _canonical_digraph()
+    pre = HierarchicalPreprocessor(graph)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", ColumnNotInHierarchyWarning)
+        pre.fit(df)
+    assert pre.is_fitted_
+
+
+def test_fit_no_columns_no_validation_error():
+    """fit(X) with no columns uses the positional default and does not raise."""
+    X, hierarchy = _six_column_setup()
+    pre = HierarchicalPreprocessor(hierarchy)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", ColumnNotInHierarchyWarning)
+        pre.fit(X)
+    assert pre.is_fitted_
+
+
+def test_fit_rejects_duplicate_dataframe_column_names():
+    """Duplicate DataFrame column names (feature_names_in_) are rejected.
+
+    validate_data captures DataFrame column labels verbatim into
+    feature_names_in_ without deduplication, so two columns sharing a name
+    auto-derive to the same hierarchy node. The fit-time guard catches it.
+    """
+    df = pd.DataFrame(
+        np.array([[1, 0, 1], [0, 1, 1]], dtype=bool),
+        columns=["dog", "dog", "cat"],
+    )
+    graph = nx.DiGraph([("animal", "dog"), ("animal", "cat")])
+    pre = HierarchicalPreprocessor(graph)
+    with pytest.raises(ValueError, match="Duplicate"):
+        pre.fit(df)


### PR DESCRIPTION
Introduced an additional check whether the column mappings are unique. If they were not, either the `columns` list or the DataFrame initially passed to the Preprocessor by the user has duplicate column names (or indices) – and raise a ValueError.

Added corresponding tests (LLM-generated, manually validated).

Also removed dead code (`connect_dag`) in *helpers.py* and its references in the remainder of the repository. This closes #113 