### PR TITLE
Sparse hierarchy default

### DIFF
--- a/doc/preprocessing.rst
+++ b/doc/preprocessing.rst
@@ -75,6 +75,13 @@ The following function demonstrates how to use `HierarchicalPreprocessor` to pre
        columns_updated = preprocessor.get_columns()
        return X_train_transformed, X_test_transformed, hierarchy_updated, columns_updated
 
+.. note::
+   ``to_adjacency_matrix()`` returns a ``scipy.sparse`` CSR array **by default**
+   (``sparse=True``). The selectors accept a sparse hierarchy directly, so the
+   updated hierarchy can be fed straight back into a selector without
+   densifying -- which at large scale avoids allocating a dense adjacency matrix.
+   Pass ``sparse=False`` if you specifically need a dense ``np.ndarray``.
+
 
 Handling Node Name Changes
 ---------------------------

--- a/scihfs/preprocessing.py
+++ b/scihfs/preprocessing.py
@@ -45,11 +45,12 @@ class HierarchicalPreprocessor(HierarchicalEstimator):
 
         Parameters
         ----------
-        hierarchy : np.ndarray or nx.DiGraph
-                    The hierarchy graph. Either an adjacency matrix
-                    (``np.ndarray``), whose nodes are the integer column
-                    positions, or a ``networkx.DiGraph`` whose nodes carry
-                    names (typically strings matching the DataFrame columns).
+        hierarchy : np.ndarray, scipy.sparse array/matrix or nx.DiGraph
+                    The hierarchy graph, given either as a dense adjacency
+                    matrix (``np.ndarray``), a sparse adjacency matrix
+                    (``scipy.sparse``), or as directly as digraph (``networkx.DiGraph``, with optional node names that can match the columns in X).
+                    Any ``scipy.sparse`` format (``csr_array``, ``csr_matrix``,
+                    ``coo_array``, ...) is accepted and converted internally.
                     Note: ``None`` is accepted for scikit-learn ``clone()`` compatibility but raises ``TypeError`` in ``fit``.
 
         .. note::
@@ -130,8 +131,15 @@ class HierarchicalPreprocessor(HierarchicalEstimator):
         # get_feature_names_out / set_output) and is redundant work here.
         self._fit_hierarchy(columns)
 
+        # Number of nodes in the ORIGINAL hierarchy provided by the user.
+        # Uses .shape[0] for the adjacency matrix case, and number_of_nodes() for the DiGraph case.
+        n_hierarchy_nodes = (
+            self.hierarchy.number_of_nodes()
+            if isinstance(self.hierarchy, nx.DiGraph)
+            else self.hierarchy.shape[0]
+        )
         self._columns = [
-            column if column < len(self.hierarchy) else -1 for column in self._columns
+            column if column < n_hierarchy_nodes else -1 for column in self._columns
         ]
 
         self._extend_dag()
@@ -212,7 +220,7 @@ class HierarchicalPreprocessor(HierarchicalEstimator):
         X_ = self._propagate_ones(X_)
         return X_
 
-    def to_adjacency_matrix(self, sparse=False):
+    def to_adjacency_matrix(self, sparse=True):
         """Return the hierarchy as an adjacency matrix (after fit).
 
         Computed from ``self._hierarchy_graph`` (which remains the immutable
@@ -220,17 +228,11 @@ class HierarchicalPreprocessor(HierarchicalEstimator):
 
         Parameters
         ----------
-        sparse : bool, default=False
+        sparse : bool, default=True
             If ``True``, return a ``scipy.sparse`` CSR array; if ``False``,
             return a dense ``np.ndarray``. Both encode the same matrix with the
             same node ordering, so ``result.toarray()`` of the sparse form
             equals its equivalent for the dense form.
-
-            .. note::
-                The sensible way to use this function is with `sparse=True`.
-                However at the moment, the default is ``False`` (dense) because the selectors do
-                not yet accept a sparse hierarchy. This behaviour is expected to flip
-                to ``True`` once selector-side sparse support will be implemented.
 
         Returns
         -------

--- a/scihfs/selectors/base.py
+++ b/scihfs/selectors/base.py
@@ -4,6 +4,7 @@ Base class for Sklearn compatible estimators using hierarchical data.
 
 import networkx as nx
 import numpy as np
+import scipy.sparse as sp
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted, validate_data
 
@@ -27,10 +28,13 @@ class HierarchicalEstimator(TransformerMixin, BaseEstimator):
 
         Parameters
         ----------
-        hierarchy : np.ndarray or nx.DiGraph
-                    The hierarchy graph, given either as an adjacency matrix
-                    (``np.ndarray``) or as a ``networkx.DiGraph`` with named
-                    nodes. ``None`` is accepted for scikit-learn ``clone()``
+        hierarchy : np.ndarray, scipy.sparse array/matrix or nx.DiGraph
+                    The hierarchy graph, given either as a dense adjacency
+                    matrix (``np.ndarray``), a sparse adjacency matrix
+                    (``scipy.sparse``), or as directly as digraph (``networkx.DiGraph``, with optional node names that can match the columns in X).
+                    Any ``scipy.sparse`` format (``csr_array``, ``csr_matrix``,
+                    ``coo_array``, ...) is accepted and converted internally.
+                    Note: ``None`` is accepted for scikit-learn ``clone()``
                     compatibility but raises ``TypeError`` in ``fit``."""
         self.hierarchy = hierarchy
 
@@ -147,22 +151,23 @@ class HierarchicalEstimator(TransformerMixin, BaseEstimator):
     def _set_hierarchy(self):
         """Build ``self._hierarchy_graph`` from ``self.hierarchy``.
 
-        The ``hierarchy`` parameter is accepted in two formats:
+        The ``hierarchy`` parameter is accepted in three formats:
 
         - ``np.ndarray``: interpreted as an adjacency matrix; nodes are the
-          integer row/column positions (existing behaviour).
+          integer row/column positions.
+        - ``scipy.sparse`` array/matrix: interpreted as a sparse adjacency
+          matrix; nodes are the integer row/column positions.
         - ``nx.DiGraph``: nodes may carry arbitrary (e.g. string) names. They
           are relabelled to integer positions ``0..n-1`` (preserving node
           order) so the rest of the pipeline keeps operating on integer node
           names.
 
-        In both cases each node is stamped with an ``ORIGINAL_NODE_IDENTIFIER``
-        attribute recording its original identity -- the integer index for an
-        adjacency matrix, the node name for a ``DiGraph``. The attribute travels
-        with the node through the later relabel/shrink/adjust passes (networkx
-        preserves node attributes across ``relabel_nodes``), so
-        ``get_feature_names_out`` can map each output column back to its original
-        node even after the internal renumbering.
+        In all three cases each node is stamped with an
+        ``ORIGINAL_NODE_IDENTIFIER`` attribute recording its original identity --
+        the integer row/column index for an adjacency matrix, or the node name for a ``DiGraph``.
+
+        The hierarchy is stored as a purely structural DAG: only edge
+        *presence* is kept, never magnitude (edge weights are dropped).
 
         The user's original ``DiGraph`` is never mutated: ``relabel_nodes`` is
         called with ``copy=True`` and the virtual ROOT is added to the copy.
@@ -172,12 +177,21 @@ class HierarchicalEstimator(TransformerMixin, BaseEstimator):
         Raises
         ------
         TypeError
-            If ``hierarchy`` is None or neither ``np.ndarray`` nor ``nx.DiGraph``.
+            If ``hierarchy`` is None or is none of ``np.ndarray``,
+            ``scipy.sparse``, or ``nx.DiGraph``.
         """
         if self.hierarchy is None:
             raise TypeError("Hierarchy is None but is required.")
         if isinstance(self.hierarchy, np.ndarray):
             hierarchy_graph = nx.from_numpy_array(self.hierarchy, create_using=nx.DiGraph)
+            # Adjacency nodes already ARE their original integer indices.
+            original_identifiers = {
+                node_index: node_index for node_index in hierarchy_graph.nodes
+            }
+        elif sp.issparse(self.hierarchy):
+            hierarchy_graph = nx.from_scipy_sparse_array(
+                self.hierarchy, create_using=nx.DiGraph
+            )
             # Adjacency nodes already ARE their original integer indices.
             original_identifiers = {
                 node_index: node_index for node_index in hierarchy_graph.nodes
@@ -193,12 +207,17 @@ class HierarchicalEstimator(TransformerMixin, BaseEstimator):
             }
         else:
             raise TypeError(
-                f"hierarchy must be np.ndarray or nx.DiGraph, "
+                f"hierarchy must be np.ndarray, scipy.sparse or nx.DiGraph, "
                 f"got {type(self.hierarchy)}."
             )
         nx.set_node_attributes(
             hierarchy_graph, original_identifiers, ORIGINAL_NODE_IDENTIFIER
         )
+        # The hierarchy is purely meant as structural information.
+        # Thus, any edge weights from the user input are dropped.
+        # This also ensures that to_adjacency_matrix returns a boolean matrix, which is expected by the rest of the pipeline.
+        for _, _, edge_data in hierarchy_graph.edges(data=True):
+            edge_data.pop("weight", None)
         # Add "ROOT" node and connect components if there are multiple
         self._hierarchy_graph = add_virtual_root_node(hierarchy_graph)
 

--- a/scihfs/selectors/eagerHierarchicalFeatureSelector.py
+++ b/scihfs/selectors/eagerHierarchicalFeatureSelector.py
@@ -19,8 +19,10 @@ class EagerHierarchicalFeatureSelector(SelectorMixin, HierarchicalEstimator):
 
         Parameters
         ----------
-        hierarchy : np.ndarray
-                    The hierarchy graph as an adjacency matrix."""
+        hierarchy : np.ndarray, scipy.sparse array/matrix or nx.DiGraph
+                    The hierarchy graph, given either as a dense adjacency
+                    matrix (``np.ndarray``), a sparse adjacency matrix
+                    (``scipy.sparse``), or as directly as digraph (``networkx.DiGraph``, with optional node names that can match the columns in X)."""
         super().__init__(hierarchy)
 
     def fit(self, X, y=None, columns=None):

--- a/scihfs/selectors/gtd.py
+++ b/scihfs/selectors/gtd.py
@@ -26,8 +26,10 @@ class GreedyTopDownSelector(EagerHierarchicalFeatureSelector):
 
         Parameters
         ----------
-        hierarchy : np.ndarray
-                    The hierarchy graph as an adjacency matrix.
+        hierarchy : np.ndarray, scipy.sparse array/matrix or nx.DiGraph
+                    The hierarchy graph, given either as a dense adjacency
+                    matrix (``np.ndarray``), a sparse adjacency matrix
+                    (``scipy.sparse``), or as directly as digraph (``networkx.DiGraph``, with optional node names that can match the columns in X).
         iterate_first_level : bool
                             The feature selection algorithm proposed by Lu et
                             al. assumes that the hierarchy has a tree

--- a/scihfs/selectors/hill_climbing.py
+++ b/scihfs/selectors/hill_climbing.py
@@ -30,8 +30,10 @@ class HillClimbingSelector(EagerHierarchicalFeatureSelector):
 
         Parameters
         ----------
-        hierarchy : np.ndarray
-                    The hierarchy graph as an adjacency matrix.
+        hierarchy : np.ndarray, scipy.sparse array/matrix or nx.DiGraph
+                    The hierarchy graph, given either as a dense adjacency
+                    matrix (``np.ndarray``), a sparse adjacency matrix
+                    (``scipy.sparse``), or as directly as digraph (``networkx.DiGraph``, with optional node names that can match the columns in X).
         alpha: float
                 A hyperparameter needed for the hill climbing methods.
                 The default value is 0.99.
@@ -202,8 +204,10 @@ class TopDownSelector(HillClimbingSelector):
 
         Parameters
         ----------
-        hierarchy : np.ndarray
-                    The hierarchy graph as an adjacency matrix.
+        hierarchy : np.ndarray, scipy.sparse array/matrix or nx.DiGraph
+                    The hierarchy graph, given either as a dense adjacency
+                    matrix (``np.ndarray``), a sparse adjacency matrix
+                    (``scipy.sparse``), or as directly as digraph (``networkx.DiGraph``, with optional node names that can match the columns in X).
         alpha: float
                 A hyperparameter needed for the hill climbing methods.
                 The default value is 0.99.
@@ -358,10 +362,12 @@ class BottomUpSelector(HillClimbingSelector):
 
         Parameters
         ----------
-        hierarchy : np.ndarray
-                    The hierarchy graph as an adjacency matrix. For this
-                    feature selection method to work as intended the graph
-                    needs to be a tree.
+        hierarchy : np.ndarray, scipy.sparse array/matrix or nx.DiGraph
+                    The hierarchy graph, given either as a dense adjacency
+                    matrix (``np.ndarray``), a sparse adjacency matrix
+                    (``scipy.sparse``), or as directly as digraph (``networkx.DiGraph``, with optional node names that can match the columns in X).
+                    For this feature selection method to work as
+                    intended the graph needs to be a tree.
         alpha: float
                 A hyperparameter needed for the feature selection. In
                 the paper by Wang et al. this parameter is called beta.

--- a/scihfs/selectors/hip.py
+++ b/scihfs/selectors/hip.py
@@ -14,8 +14,10 @@ class HIP(LazyHierarchicalFeatureSelector):
 
         Parameters
         ----------
-        hierarchy : np.ndarray
-                    The hierarchy graph as an adjacency matrix.
+        hierarchy : np.ndarray, scipy.sparse array/matrix or nx.DiGraph
+                    The hierarchy graph, given either as a dense adjacency
+                    matrix (``np.ndarray``), a sparse adjacency matrix
+                    (``scipy.sparse``), or as directly as digraph (``networkx.DiGraph``, with optional node names that can match the columns in X).
         """
         super(HIP, self).__init__(hierarchy)
 

--- a/scihfs/selectors/hnb.py
+++ b/scihfs/selectors/hnb.py
@@ -16,8 +16,10 @@ class HNB(LazyHierarchicalFeatureSelector):
 
         Parameters
         ----------
-        hierarchy : np.ndarray
-            The hierarchy graph as an adjacency matrix.
+        hierarchy : np.ndarray, scipy.sparse array/matrix or nx.DiGraph
+            The hierarchy graph, given either as a dense adjacency
+            matrix (``np.ndarray``), a sparse adjacency matrix
+            (``scipy.sparse``), or as directly as digraph (``networkx.DiGraph``, with optional node names that can match the columns in X).
         k : int
             The numbers of features to select.
         """

--- a/scihfs/selectors/hnbs.py
+++ b/scihfs/selectors/hnbs.py
@@ -16,8 +16,10 @@ class HNBs(LazyHierarchicalFeatureSelector):
 
         Parameters
         ----------
-        hierarchy: np.ndarray
-            The hierarchy graph as an adjacency matrix.
+        hierarchy : np.ndarray, scipy.sparse array/matrix or nx.DiGraph
+            The hierarchy graph, given either as a dense adjacency
+            matrix (``np.ndarray``), a sparse adjacency matrix
+            (``scipy.sparse``), or as directly as digraph (``networkx.DiGraph``, with optional node names that can match the columns in X).
         """
         super(HNBs, self).__init__(hierarchy)
 

--- a/scihfs/selectors/lazyHierarchicalFeatureSelector.py
+++ b/scihfs/selectors/lazyHierarchicalFeatureSelector.py
@@ -24,8 +24,10 @@ class LazyHierarchicalFeatureSelector(ABC, HierarchicalEstimator):
 
         Parameters
         ----------
-        hierarchy : np.ndarray
-            The hierarchy graph as an adjacency matrix.
+        hierarchy : np.ndarray, scipy.sparse array/matrix or nx.DiGraph
+            The hierarchy graph, given either as a dense adjacency
+            matrix (``np.ndarray``), a sparse adjacency matrix
+            (``scipy.sparse``), or as directly as digraph (``networkx.DiGraph``, with optional node names that can match the columns in X).
         """
         self.hierarchy = hierarchy
 

--- a/scihfs/selectors/mr.py
+++ b/scihfs/selectors/mr.py
@@ -17,8 +17,10 @@ class MR(LazyHierarchicalFeatureSelector):
 
         Parameters
         ----------
-        hierarchy : np.ndarray
-                    The hierarchy graph as an adjacency matrix.
+        hierarchy : np.ndarray, scipy.sparse array/matrix or nx.DiGraph
+                    The hierarchy graph, given either as a dense adjacency
+                    matrix (``np.ndarray``), a sparse adjacency matrix
+                    (``scipy.sparse``), or as directly as digraph (``networkx.DiGraph``, with optional node names that can match the columns in X).
         """
 
     def select_and_predict(

--- a/scihfs/selectors/rnb.py
+++ b/scihfs/selectors/rnb.py
@@ -17,8 +17,10 @@ class RNB(LazyHierarchicalFeatureSelector):
 
         Parameters
         ----------
-        hierarchy : np.ndarray
-            The hierarchy graph as an adjacency matrix.
+        hierarchy : np.ndarray, scipy.sparse array/matrix or nx.DiGraph
+            The hierarchy graph, given either as a dense adjacency
+            matrix (``np.ndarray``), a sparse adjacency matrix
+            (``scipy.sparse``), or as directly as digraph (``networkx.DiGraph``, with optional node names that can match the columns in X).
         k : int
             The numbers of features to select.
         """

--- a/scihfs/selectors/shsel.py
+++ b/scihfs/selectors/shsel.py
@@ -39,8 +39,10 @@ class SHSELSelector(EagerHierarchicalFeatureSelector):
 
         Parameters
         ----------
-        hierarchy : np.ndarray
-                    The hierarchy graph as an adjacency matrix.
+        hierarchy : np.ndarray, scipy.sparse array/matrix or nx.DiGraph
+                    The hierarchy graph, given either as a dense adjacency
+                    matrix (``np.ndarray``), a sparse adjacency matrix
+                    (``scipy.sparse``), or as directly as digraph (``networkx.DiGraph``, with optional node names that can match the columns in X).
         relevance_metric : str
                     The relevance metric to use in the initial selection
                     stage of the algorithm. The options ore "IG" for

--- a/scihfs/selectors/tan.py
+++ b/scihfs/selectors/tan.py
@@ -16,8 +16,10 @@ class TAN(LazyHierarchicalFeatureSelector):
 
         Parameters
         ----------
-        hierarchy : np.ndarray
-            The hierarchy graph as an adjacency matrix.
+        hierarchy : np.ndarray, scipy.sparse array/matrix or nx.DiGraph
+            The hierarchy graph, given either as a dense adjacency
+            matrix (``np.ndarray``), a sparse adjacency matrix
+            (``scipy.sparse``), or as directly as digraph (``networkx.DiGraph``, with optional node names that can match the columns in X).
         """
         super(TAN, self).__init__(hierarchy)
 

--- a/scihfs/selectors/tsel.py
+++ b/scihfs/selectors/tsel.py
@@ -29,10 +29,12 @@ class TSELSelector(EagerHierarchicalFeatureSelector):
 
         Parameters
         ----------
-        hierarchy : np.ndarray
-                    The hierarchy graph as an adjacency matrix. The
-                    feature selection method is intended for a hierarchy
-                    graph that has a tree structure.
+        hierarchy : np.ndarray, scipy.sparse array/matrix or nx.DiGraph
+                    The hierarchy graph, given either as a dense adjacency
+                    matrix (``np.ndarray``), a sparse adjacency matrix
+                    (``scipy.sparse``), or as directly as digraph (``networkx.DiGraph``, with optional node names that can match the columns in X).
+                    The feature selection method is intended for a
+                    hierarchy graph that has a tree structure.
         use_original_implementation: bool
                     Should the original implementation from the
                     paper be used. If False, a slightly different

--- a/scihfs/tests/test_preprocessing.py
+++ b/scihfs/tests/test_preprocessing.py
@@ -26,7 +26,7 @@ def test_hierarchical_preprocessor(data, request):
     assert preprocessor.is_fitted_
     X = preprocessor.transform(X)
     assert np.array_equal(X, X_transformed)
-    hierarchy_transformed = preprocessor.to_adjacency_matrix()
+    hierarchy_transformed = preprocessor.to_adjacency_matrix(sparse=False)
     assert np.array_equal(hierarchy_transformed, hierarchy_expected)
 
 
@@ -35,7 +35,7 @@ def test_fit(data3_preprocessing):
     preprocessor = HierarchicalPreprocessor(hierarchy)
     preprocessor.fit(X.astype(bool), columns=X_identifiers)
     assert preprocessor.is_fitted_
-    hierarchy = preprocessor.to_adjacency_matrix()
+    hierarchy = preprocessor.to_adjacency_matrix(sparse=False)
     assert np.equal(hierarchy.all(), hierarchy_transformed.all())
 
 
@@ -533,6 +533,76 @@ def test_preprocessor_sparse_canonical_equivalence():
     assert np.array_equal(out_s.toarray().astype(int), _EXPECTED_CANONICAL)
 
 
+def test_hierarchical_estimator_accepts_sparse_hierarchy():
+    """A scipy.sparse adjacency hierarchy behaves exactly like the dense ndarray.
+
+    A sparse adjacency is positionally identical to its dense equivalent, so the
+    sparse-input branch of _set_hierarchy stamps the same integer-index
+    ORIGINAL_NODE_IDENTIFIER attributes and yields the same fitted hierarchy,
+    column mapping, transform output AND feature names as the dense ndarray path.
+    """
+    from scihfs.selectors.base import ORIGINAL_NODE_IDENTIFIER
+
+    X, hierarchy, columns = _canonical_setup()  # hierarchy is a dense ndarray
+    sparse_hierarchy = sp.csr_array(hierarchy)
+    assert sp.issparse(sparse_hierarchy)
+
+    pre_dense = HierarchicalPreprocessor(hierarchy)
+    pre_dense.fit(X, columns=columns)
+
+    pre_sparse = HierarchicalPreprocessor(sparse_hierarchy)
+    pre_sparse.fit(X, columns=columns)
+
+    # Same fitted hierarchy structure, column mapping, transform output and names.
+    assert pre_sparse.get_columns() == pre_dense.get_columns()
+    assert np.array_equal(
+        pre_sparse.to_adjacency_matrix(sparse=False),
+        pre_dense.to_adjacency_matrix(sparse=False),
+    )
+    assert np.array_equal(
+        pre_sparse.to_adjacency_matrix(sparse=True).toarray(),
+        pre_dense.to_adjacency_matrix(sparse=True).toarray(),
+    )
+    assert np.array_equal(pre_sparse.transform(X), pre_dense.transform(X))
+    assert list(pre_sparse.get_feature_names_out()) == list(
+        pre_dense.get_feature_names_out()
+    )
+
+    # Sparse and dense inputs both stamp integer-index identifiers on every node;
+    # neither falls back to the "x<node>" label.
+    for pre in (pre_dense, pre_sparse):
+        assert all(
+            ORIGINAL_NODE_IDENTIFIER in pre._hierarchy_graph.nodes[node]
+            for node in pre._hierarchy_graph.nodes
+            if node != "ROOT"
+        )
+        assert not any(n.startswith("x") for n in pre.get_feature_names_out())
+
+
+def test_hierarchy_round_trip_via_to_adjacency_matrix_sparse():
+    """A hierarchy round-trips through to_adjacency_matrix(sparse=True).
+
+    Feeding the sparse adjacency produced by one fitted preprocessor into a new
+    preprocessor yields an equivalent transform. A 1:1 column<->node hierarchy
+    is used so fit neither extends nor shrinks the graph, making the adjacency
+    round-trip exact.
+    """
+    hierarchy = nx.to_numpy_array(nx.DiGraph([(0, 1), (0, 2), (1, 3)]))
+    n = hierarchy.shape[0]
+    X = np.array([[0, 0, 0, 1], [0, 1, 0, 0], [1, 0, 1, 1]], dtype=bool)
+
+    pre1 = HierarchicalPreprocessor(hierarchy)
+    pre1.fit(X, columns=list(range(n)))
+
+    sparse_adj = pre1.to_adjacency_matrix(sparse=True)
+    assert sp.issparse(sparse_adj)
+
+    pre2 = HierarchicalPreprocessor(sparse_adj)
+    pre2.fit(X, columns=list(range(n)))
+
+    assert np.array_equal(pre1.transform(X), pre2.transform(X))
+
+
 def test_scipy_sparse_bool_matmul_preserves_bool():
     """Test whether matmul (``@``) and ``maximum()`` preserve dtype in scipy sparse arrays. This behaviour is not immediately obvious from the scipy docs at first glance, so this is just a defensive test."""
     a = sp.csr_array(np.array([[True, False], [False, True]]))
@@ -851,10 +921,10 @@ def test_none_hierarchy_raises_type_error_in_fit():
 
 
 def test_invalid_hierarchy_type_raises_type_error():
-    """A hierarchy that is neither ndarray nor DiGraph raises TypeError."""
+    """A hierarchy that is none of ndarray / scipy.sparse / DiGraph raises TypeError."""
     X = np.zeros((2, 2), dtype=bool)
     pre = HierarchicalPreprocessor("not a graph")
-    with pytest.raises(TypeError, match="must be np.ndarray or nx.DiGraph"):
+    with pytest.raises(TypeError, match="must be np.ndarray, scipy.sparse or nx.DiGraph"):
         pre.fit(X)
 
 
@@ -1151,12 +1221,12 @@ def test_to_adjacency_matrix_idempotent():
     """Repeated calls return equal arrays and leave ROOT in the graph."""
     pre = _fitted_canonical_preprocessor()
 
-    first = pre.to_adjacency_matrix()
-    second = pre.to_adjacency_matrix()
-    third = pre.to_adjacency_matrix()
+    first = pre.to_adjacency_matrix(sparse=True)
+    second = pre.to_adjacency_matrix(sparse=True)
+    third = pre.to_adjacency_matrix(sparse=True)
 
-    assert np.array_equal(first, second)
-    assert np.array_equal(second, third)
+    assert np.array_equal(first.toarray(), second.toarray())
+    assert np.array_equal(second.toarray(), third.toarray())
     # The synthetic ROOT must survive every call.
     assert "ROOT" in pre._hierarchy_graph.nodes
 
@@ -1190,16 +1260,64 @@ def test_to_adjacency_matrix_raises_before_fit():
         pre.to_adjacency_matrix()
 
 
+def test_to_adjacency_matrix_default_is_sparse():
+    """The default (no arg) returns a scipy.sparse array."""
+    pre = _fitted_canonical_preprocessor()
+    result = pre.to_adjacency_matrix()
+    assert sp.issparse(result)
+
+
+def test_to_adjacency_matrix_sparse_false_still_works():
+    """The dense opt-out (sparse=False) still returns an ndarray."""
+    pre = _fitted_canonical_preprocessor()
+    result = pre.to_adjacency_matrix(sparse=False)
+    assert isinstance(result, np.ndarray)
+
+
 def test_to_adjacency_matrix_sparse_matches_dense():
-    """sparse=True returns a scipy CSR array equal to the dense default."""
+    """sparse=True and sparse=False encode the same matrix."""
     pre = _fitted_canonical_preprocessor()
 
-    dense = pre.to_adjacency_matrix()  # default
+    dense = pre.to_adjacency_matrix(sparse=False)
     spar = pre.to_adjacency_matrix(sparse=True)
 
-    assert isinstance(dense, np.ndarray)  # default is dense
+    assert isinstance(dense, np.ndarray)
     assert sp.issparse(spar)
     assert np.array_equal(spar.toarray(), dense)
+
+
+def test_hierarchy_edge_weights_dropped_and_output_is_binary():
+    """A weighted adjacency is treated as edge presence only.
+
+    The hierarchy is purely structural: input edge weights are dropped, so
+    (a) the internal graph carries no ``weight`` edge attribute and
+    (b) ``to_adjacency_matrix`` emits only 0/1 for a present edge, never echoing
+    the input's stored magnitude.
+    """
+    # Adjacency with non-1 weights on edges 0->1, 0->2, 1->3.
+    weighted = np.array(
+        [
+            [0.0, 2.5, 7.0, 0.0],
+            [0.0, 0.0, 0.0, 3.0],
+            [0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0],
+        ]
+    )
+    X = np.array([[0, 0, 0, 1], [1, 1, 0, 0]], dtype=bool)
+
+    pre = HierarchicalPreprocessor(weighted)
+    pre.fit(X, columns=[0, 1, 2, 3])
+
+    # (a) No edge retains a 'weight' attribute.
+    assert all(
+        "weight" not in data for _, _, data in pre._hierarchy_graph.edges(data=True)
+    )
+
+    # (b) Output is binary, not the 2.5 / 7.0 / 3.0 input weights.
+    dense = pre.to_adjacency_matrix(sparse=False)
+    sparse = pre.to_adjacency_matrix(sparse=True)
+    assert set(np.unique(dense)).issubset({0.0, 1.0})
+    assert set(np.unique(sparse.toarray())).issubset({0.0, 1.0})
 
 
 def test_clone_preserves_ndarray_hierarchy_input():


### PR DESCRIPTION
The `HierarchicalEstimator` now accepts _scipy.sparse_ as data format for the hierarchy input (along _ndarray_ and _nx.DiGraph_). Default adjacency matrix export format of `to_adjacency_matrix()` is now also _scipy.sparse_

Applied downstream changes:
- Size assessment of input hierarchy now depends on its format.
- Added third option in the construction of the internal nx.DiGraph object (for the _scipy.sparse_ case).
- Added a default behaviour of dropping edge weights of the input hierarchy to reflect its behaviour as only providing structural information.
- Updated docstrings for all selectors now allowing all three data formats for the hierarchy input.

Added corresponding tests (LLM-generated, manually validated).

Closes #115 