### PR TITLE
Selectors enforce binary, sklearn conformance test reorganization

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -22,3 +22,5 @@ coverage:
 
 ignore:
   - "**/pyitlib.py"
+  # Temporary: HieAODE is suspended until its dedicated refactoring.
+  - "scihfs/selectors/hie_aode.py"

--- a/examples/eager_learning_example.py
+++ b/examples/eager_learning_example.py
@@ -23,14 +23,14 @@ import numpy as np
 from scihfs.helpers import get_columns_for_numpy_hierarchy
 from scihfs.selectors import SHSELSelector
 
-# Example dataset X with 3 samples and 5 features.
+# Example dataset X with 3 samples and 5 features, all bool-encoded binary features.
 X = np.array(
     [
         [1, 1, 0, 0, 1],
         [1, 1, 1, 1, 0],
         [1, 1, 1, 0, 0],
     ],
-)
+).astype(bool)
 
 # Example labels
 y = np.array([1, 0, 0])

--- a/examples/lazy_learning_example.py
+++ b/examples/lazy_learning_example.py
@@ -32,10 +32,8 @@ def preprocess():
     train_x_data, train_y_data, test_x_data, test_y_data, hierarchy = data()
     preprocessor = HierarchicalPreprocessor(hierarchy=hierarchy)
     preprocessor.fit(train_x_data)
-    # Downstream lazy selectors index into CPT arrays with X values, which
-    # requires integer-valued samples; cast back to int after preprocessing.
-    train = preprocessor.transform(train_x_data).astype(int)
-    test = preprocessor.transform(test_x_data).astype(int)
+    train = preprocessor.transform(train_x_data)
+    test = preprocessor.transform(test_x_data)
     hierarchy = preprocessor.to_adjacency_matrix()
     return (train, test, train_y_data, test_y_data, hierarchy)
 

--- a/examples/lazy_learning_example.py
+++ b/examples/lazy_learning_example.py
@@ -48,18 +48,21 @@ HieAODE -
 =========================================================================
 """
 
-print("\nHieAODE:")
-# Initialize and fit HNB model with threshold k = 3 features to select
-model = HieAODE(hierarchy=hierarchy)
-model.fit_selector(X_train=train, y_train=train_y_data, X_test=test)
-# %%
-# Select features and predict
-predictions = model.select_and_predict(predict=True, saveFeatures=True)
-print(predictions)
-# %%
-# Calculate score
-score = model.get_score(test_y_data, predictions)
-print(score)
+# TODO: Update this section once merged with main (currently outdated).
+# The following is the original code snippet for HieAODE, now commented out.
+
+# print("\nHieAODE:")
+# # Initialize and fit HNB model with threshold k = 3 features to select
+# model = HieAODE(hierarchy=hierarchy)
+# model.fit_selector(X_train=train, y_train=train_y_data, X_test=test)
+# # %%
+# # Select features and predict
+# predictions = model.select_and_predict(predict=True, saveFeatures=True)
+# print(predictions)
+# # %%
+# # Calculate score
+# score = model.get_score(test_y_data, predictions)
+# print(score)
 
 """
 =========================================================================

--- a/scihfs/helpers.py
+++ b/scihfs/helpers.py
@@ -2,12 +2,13 @@
 Collection of helper methods for the feature selection algorithms.
 """
 
-import math
+# import math
 import warnings
 from fractions import Fraction
 
 import networkx as nx
 import numpy as np
+import scipy.sparse as sp
 from networkx.algorithms.simple_paths import all_simple_paths
 
 
@@ -262,23 +263,24 @@ def get_columns_for_numpy_hierarchy(hierarchy: nx.DiGraph, num_columns: int):
     return columns
 
 
-def normalize_score(score, max_value):
-    """Normalize the given score using logarithmic scaling and a maximum value.
+# Numerical input is currently not supported and previous related code has been commented out throughout this repository.
+# def normalize_score(score, max_value):
+#     """Normalize the given score using logarithmic scaling and a maximum value.
 
-    Parameters
-    ----------
-    score : float or int
-            The score to be normalized.
-    max_value : float or int
-            The maximum of the scores in the corresponding row.
+#     Parameters
+#     ----------
+#     score : float or int
+#             The score to be normalized.
+#     max_value : float or int
+#             The maximum of the scores in the corresponding row.
 
-    Returns
-    ----------
-    float or int : The normalized score after applying logarithmic scaling.
-    """
-    if score != 0:
-        score = math.log(1 + (score / max_value)) + 1
-    return score
+#     Returns
+#     ----------
+#     float or int : The normalized score after applying logarithmic scaling.
+#     """
+#     if score != 0:
+#         score = math.log(1 + (score / max_value)) + 1
+#     return score
 
 
 def compute_aggregated_values(X, hierarchy: nx.DiGraph, columns: list[int], node="ROOT"):
@@ -310,6 +312,12 @@ def compute_aggregated_values(X, hierarchy: nx.DiGraph, columns: list[int], node
         The input array `X` with the aggregated values based on the provided
         hierarchy.
     """
+    # Sparse input is accepted throughout the library, but
+    # currently 'densified' here. To avoid excessive memory
+    # allocation, add a dedicated sparse implementation here in
+    # the future.
+    if sp.issparse(X):
+        X = X.toarray()
     # Note that we deliberately use uint32 (unsigned, min 0, max 4294967295), to keep memory footprint low and because feature counts are always positive integers.
     if X.dtype == np.bool_:
         X = X.astype(np.uint32)

--- a/scihfs/helpers.py
+++ b/scihfs/helpers.py
@@ -310,10 +310,13 @@ def compute_aggregated_values(X, hierarchy: nx.DiGraph, columns: list[int], node
         The input array `X` with the aggregated values based on the provided
         hierarchy.
     """
+    # Note that we deliberately use uint32 (unsigned, min 0, max 4294967295), to keep memory footprint low and because feature counts are always positive integers.
+    if X.dtype == np.bool_:
+        X = X.astype(np.uint32)
     if hierarchy.out_degree(node) == 0:
         return X
     children = hierarchy.successors(node)
-    aggregated = np.zeros((X.shape[0]))
+    aggregated = np.zeros((X.shape[0]), dtype=np.uint32)
     for child in list(children):
         X = compute_aggregated_values(X, hierarchy, columns, node=child)
         aggregated = np.add(aggregated, X[:, columns.index(child)])

--- a/scihfs/metrics.py
+++ b/scihfs/metrics.py
@@ -124,6 +124,11 @@ def cosine_similarity(i: np.ndarray, j: np.ndarray):
     ----------
     float : The cosine similarity for the input rows.
     """
+    # Input are non-negative uint32 count vectors. Upcast to uint64 to avoid overflow
+    # np.linalg.norm promotes to float internally, and so does final uint64 / (float * float).
+    # NOTE: This function currently assumes integer input - if float scores were reintroduced, this section would need to be updated (branched on dtype).
+    i = i.astype(np.uint64)
+    j = j.astype(np.uint64)
     return np.dot(i, j) / (norm(i) * norm(j))
 
 

--- a/scihfs/selectors/base.py
+++ b/scihfs/selectors/base.py
@@ -8,7 +8,11 @@ import scipy.sparse as sp
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted, validate_data
 
-from scihfs.helpers import _check_unique_column_mappings, add_virtual_root_node
+from scihfs.helpers import (
+    _check_unique_column_mappings,
+    add_virtual_root_node,
+    check_bool_dtype,
+)
 
 # Node-attribute key for recording a node's original identity (name or index) in the hierarchy graph. Left untouched by all operations on the graph.
 # Consumed by get_feature_names_out to map back to original node names / indexes.
@@ -21,6 +25,10 @@ class HierarchicalEstimator(TransformerMixin, BaseEstimator):
     The HierarchicalEstimator implements scikit-learn's BaseEstimator and
     TransformerMixin interfaces. It can be used as a base class for feature
     selection classes or data preprocessors that use hierarchical data.
+
+    ..note:: This estimator currently supports only bool-dtype input.
+    Non-binary (numeric) inputs raise ``ValueError``. Sum-propagation
+    for numeric features could be a future enhancement.
     """
 
     def __init__(self, hierarchy=None):
@@ -65,6 +73,8 @@ class HierarchicalEstimator(TransformerMixin, BaseEstimator):
         ------
         TypeError
             If the passed hierarchy is None.
+        ValueError
+            If X is not bool-dtype. Numerical inputs may be supported in the future.
 
         Returns
         -------
@@ -74,6 +84,7 @@ class HierarchicalEstimator(TransformerMixin, BaseEstimator):
         if self.hierarchy is None:
             raise TypeError("Hierarchy is None but is required.")
         X = validate_data(self, X, accept_sparse=True)
+        check_bool_dtype(X)
         self._fit_hierarchy(columns)
 
         return self

--- a/scihfs/selectors/hill_climbing.py
+++ b/scihfs/selectors/hill_climbing.py
@@ -8,7 +8,9 @@ import numpy as np
 from scipy import sparse
 from sklearn.utils.validation import validate_data
 
-from scihfs.helpers import compute_aggregated_values, get_leaves, normalize_score
+# Numerical input is not supported and previous related code commented out throughout this file, such as the 'dataset_type' variable with "binary" and "numerical" branches.
+# Restore the `normalize_score` import here when reintroducing.
+from scihfs.helpers import compute_aggregated_values, get_leaves
 from scihfs.metrics import cosine_similarity
 from scihfs.selectors import EagerHierarchicalFeatureSelector
 
@@ -24,7 +26,7 @@ class HillClimbingSelector(EagerHierarchicalFeatureSelector):
         self,
         hierarchy: np.ndarray = None,
         alpha: float = 0.99,
-        dataset_type: str = "binary",
+        # dataset_type: str = "binary",
     ):
         """Initializes a HillClimbingSelector.
 
@@ -37,13 +39,19 @@ class HillClimbingSelector(EagerHierarchicalFeatureSelector):
         alpha: float
                 A hyperparameter needed for the hill climbing methods.
                 The default value is 0.99.
+
+        Notes
+        -----
+        Numerical input is currently not supported. Corresponding code is retained (but inactive) for future reintroduction.
+        This also applies to the `dataset_type` parameter.
+
         dataset_type: string, either "binary" or "numerical"
                 A value indicating if the input dataset contains binary or
                 numerical data. Default is "binary".
         """
         super().__init__(hierarchy)
         self.alpha = alpha
-        self.dataset_type = dataset_type
+        # self.dataset_type = dataset_type
 
     def fit(self, X, y, columns=None):
         """Fitting function that sets self.representatives\_.
@@ -121,15 +129,15 @@ class HillClimbingSelector(EagerHierarchicalFeatureSelector):
             X.copy(), self._hierarchy_graph, self._columns
         )
 
-        if self.dataset_type == "numerical":
-            normalized_matrix = np.zeros_like(score_matrix, dtype=float)
-            for row_index in range(self._num_rows):
-                for column_index in range(self.n_features_in_):
-                    score = score_matrix[row_index, column_index]
-                    normalized_matrix[row_index, column_index] = normalize_score(
-                        score, max(score_matrix[row_index, :])
-                    )
-            score_matrix = normalized_matrix
+        # if self.dataset_type == "numerical":
+        #     normalized_matrix = np.zeros_like(score_matrix, dtype=float)
+        #     for row_index in range(self._num_rows):
+        #         for column_index in range(self.n_features_in_):
+        #             score = score_matrix[row_index, column_index]
+        #             normalized_matrix[row_index, column_index] = normalize_score(
+        #                 score, max(score_matrix[row_index, :])
+        #             )
+        #     score_matrix = normalized_matrix
         return score_matrix
 
     def _compare(
@@ -198,7 +206,7 @@ class TopDownSelector(HillClimbingSelector):
         self,
         hierarchy: np.ndarray = None,
         alpha: float = 0.99,
-        dataset_type: str = "binary",
+        # dataset_type: str = "binary",
     ):
         """Initializes a TopDownSelector.
 
@@ -211,11 +219,18 @@ class TopDownSelector(HillClimbingSelector):
         alpha: float
                 A hyperparameter needed for the hill climbing methods.
                 The default value is 0.99.
+
+        Notes
+        -----
+        Numerical input is currently not supported. Corresponding code is retained (but inactive) for future reintroduction.
+        This also applies to the `dataset_type` parameter.
+
         dataset_type: string, either "binary" or "numerical"
                 A value indicating if the input dataset contains binary or
                 numerical data. Default is "binary".
         """
-        super().__init__(hierarchy, alpha=alpha, dataset_type=dataset_type)
+        # dataset_type disabled:
+        super().__init__(hierarchy, alpha=alpha)
 
     def fit(self, X, y, columns=None):
         """Fitting function that sets self.representatives\_.
@@ -357,7 +372,7 @@ class BottomUpSelector(HillClimbingSelector):
         hierarchy: np.ndarray = None,
         alpha: float = 0.01,
         k: int = 5,
-        dataset_type: str = "binary",
+        # dataset_type: str = "binary",
     ):
         """Initializes a BottomUpSelector.
 
@@ -377,11 +392,18 @@ class BottomUpSelector(HillClimbingSelector):
                 A hyperparameter needed to determine the k nearest
                 neighbors during the feature selection algorithm.
                 The default value is 5.
+
+        Notes
+        -----
+        Numerical input is currently not supported. Corresponding code is retained (but inactive) for future reintroduction.
+        This also applies to the `dataset_type` parameter.
+
         dataset_type: string, either "binary" or "numerical"
                 A value indicating if the input dataset contains binary or
                 numerical data. Default is "binary".
         """
-        super().__init__(hierarchy, alpha=alpha, dataset_type=dataset_type)
+        # dataset_type disabled:
+        super().__init__(hierarchy, alpha=alpha)
         self.k = k
 
     def fit(self, X, y, columns=None):

--- a/scihfs/selectors/hill_climbing.py
+++ b/scihfs/selectors/hill_climbing.py
@@ -315,11 +315,12 @@ class TopDownSelector(HillClimbingSelector):
         distance = 0
         for column in feature_set:
             column_index = self._column_index(column)
-            difference = (
-                self._score_matrix[sample_i, column_index]
-                - self._score_matrix[sample_j, column_index]
+            # To accomodate large int (squares+sum), the uint32 input (_score_matrix coming from compute_aggregated_values) is transiently transformed to unbounded integers.
+            # The sqrt at the end transforms the int input to float output.
+            difference = int(self._score_matrix[sample_i, column_index]) - int(
+                self._score_matrix[sample_j, column_index]
             )
-            distance += math.pow(difference, 2)
+            distance += difference * difference
         return math.sqrt(distance)
 
     def _fitness_function(self, comparison_matrix: np.ndarray) -> float:

--- a/scihfs/selectors/hill_climbing.py
+++ b/scihfs/selectors/hill_climbing.py
@@ -456,6 +456,13 @@ class BottomUpSelector(HillClimbingSelector):
                     A list of nodes (int or str) that represent the
                     optimal features set.
         """
+        # The kNN implementation in this file requires n_samples > k_neighbors.
+        if self._num_rows <= self.k:
+            raise ValueError(
+                f"BottomUpSelector needs n (samples) > k (neighbors) for the k-nearest-"
+                f"neighbors step, but got n_samples={self._num_rows} with "
+                f"k={self.k}."
+            )
         self._score_matrix = self._calculate_scores(X)
 
         # Start with the leaves.

--- a/scihfs/selectors/lazyHierarchicalFeatureSelector.py
+++ b/scihfs/selectors/lazyHierarchicalFeatureSelector.py
@@ -6,7 +6,7 @@ from sklearn.metrics import classification_report
 from sklearn.naive_bayes import BernoulliNB
 from sklearn.utils.validation import validate_data
 
-from scihfs.helpers import check_data, get_relevance
+from scihfs.helpers import check_bool_dtype, check_data, get_relevance
 from scihfs.metrics import conditional_mutual_information
 from scihfs.selectors import HierarchicalEstimator
 
@@ -48,6 +48,7 @@ class LazyHierarchicalFeatureSelector(ABC, HierarchicalEstimator):
             Fitted estimator.
         """
         X = validate_data(self, X, accept_sparse=True)
+        check_bool_dtype(X)
         if y is not None:
             if not isinstance(y, np.ndarray):
                 try:
@@ -74,7 +75,14 @@ class LazyHierarchicalFeatureSelector(ABC, HierarchicalEstimator):
             converted into a sparse ``csc_matrix``.
         y_train : array-like of shape (n_samples, n_levels)
             The target values, i.e., hierarchical class labels for classification.
+
+        Raises
+        ------
+        ValueError
+            If X_train or X_test is not bool-dtype.
         """
+        check_bool_dtype(X_train)
+        check_bool_dtype(X_test)
         # Create DAG
         self.n_features_in_ = X_train.shape[1]
         self.n_classes_ = np.unique(y_train).shape[0]

--- a/scihfs/selectors/shsel.py
+++ b/scihfs/selectors/shsel.py
@@ -3,13 +3,14 @@ SHSEL Feature Selector.
 """
 
 import statistics
-import warnings
 
 import numpy as np
 from scipy import sparse
 from sklearn.utils.validation import validate_data
 
-from scihfs.helpers import compute_aggregated_values, get_leaves, get_paths
+# The HFE extension from Oudah and Henschel (2018) is commented out below, as it requires numerical features in the input (currently only bool supported).
+# When it is restored, also restore the `compute_aggregated_values` and `get_leaves` imports.
+from scihfs.helpers import get_paths
 from scihfs.metrics import information_gain, pearson_correlation
 from scihfs.selectors import EagerHierarchicalFeatureSelector
 
@@ -22,9 +23,11 @@ class SHSELSelector(EagerHierarchicalFeatureSelector):
     parents that have a similar relevance and removing features with
     lower than average information gain for each path from leaf to
     root.
-    This Selector also implements the hierarchical feature
-    engineering (HFE) extension proposed by Oudah and Henschel in
-    2018.
+
+    The hierarchical feature engineering (HFE) extension proposed by
+    Oudah and Henschel (2018) is temporarily disabled. It requires
+    numerical input which is currently not supported.
+    Corresponding code is retained (but commented out).
     """
 
     def __init__(
@@ -32,8 +35,9 @@ class SHSELSelector(EagerHierarchicalFeatureSelector):
         hierarchy: np.ndarray = None,
         relevance_metric: str = "IG",
         similarity_threshold=0.99,
-        use_hfe_extension=False,
-        preprocess_numerical_data=False,
+        # HFE extension disabled:
+        # use_hfe_extension=False,
+        # preprocess_numerical_data=False,
     ):
         """Initializes a SHSELSelector.
 
@@ -51,6 +55,15 @@ class SHSELSelector(EagerHierarchicalFeatureSelector):
                     The similarity threshold to use in the initial selection
                     stage of the algorithm. This can be a number between
                     0 an 1. Default is 0.99.
+
+        Notes
+        -----
+        The hierarchical feature engineering (HFE) extension proposed
+        by Oudah and Henschel (2018) is temporarily disabled. It
+        requires numerical input which is currently not supported.
+        Corresponding code is retained though (but commented out),
+        such as the following two parameters, which are not active:
+
         use_hfe_extension : bool
                     If True the HFE algorithm proposed by Oudah and Henschel is
                     used. Set relevance_metric to "Correlation" when using this
@@ -60,13 +73,13 @@ class SHSELSelector(EagerHierarchicalFeatureSelector):
                     This method is used in the HFE extension algorithm which
                     expects numerical data. If binary data is used it is
                     recommended to set this parameter to False. Default is False.
-
         """
         super().__init__(hierarchy)
         self.relevance_metric = relevance_metric
         self.similarity_threshold = similarity_threshold
-        self.use_hfe_extension = use_hfe_extension
-        self.preprocess_numerical_data = preprocess_numerical_data
+        # HFE extension disabled:
+        # self.use_hfe_extension = use_hfe_extension
+        # self.preprocess_numerical_data = preprocess_numerical_data
 
     def fit(self, X, y, columns=None):
         """Fitting function that sets self.representatives\_.
@@ -99,22 +112,14 @@ class SHSELSelector(EagerHierarchicalFeatureSelector):
             Returns self.
         """
         # Input validation
-        if self.use_hfe_extension and self.relevance_metric != "Correlation":
-            raise ValueError(
-                "When using the HFE extension the relevance_metric should be 'Correlation'."
-            )
+        # HFE extension disabled:
+        # if self.use_hfe_extension and self.relevance_metric != "Correlation":
+        #     raise ValueError(
+        #         "When using the HFE extension the relevance_metric should be 'Correlation'."
+        #     )
         X, y = validate_data(self, X, y, accept_sparse=True)
         if sparse.issparse(X):
             X = X.tocsc()
-        if not self.use_hfe_extension:
-            # make sure data is binary when SHSEL without extension is used
-            if not np.all((X.data == 0) | (X.data == 1)):
-                warnings.warn(
-                    "The sparse data is not binary. "
-                    "When using the original SHSEL algorithm, "
-                    "the data should contain only 0s and 1s.",
-                    UserWarning,
-                )
 
         super().fit(X, y, columns)
 
@@ -127,13 +132,15 @@ class SHSELSelector(EagerHierarchicalFeatureSelector):
 
     def _fit(self, X):
         """The feature selection algorithm."""
-        if self.preprocess_numerical_data:
-            X = self._preprocess(X)
+        # HFE extension disabled:
+        # if self.preprocess_numerical_data:
+        #     X = self._preprocess(X)
         paths = get_paths(self._hierarchy_graph, reverse=True)
         self._inital_selection(paths, X)
         self._pruning(paths)
-        if self.use_hfe_extension:
-            self._leaf_filtering()
+        # HFE extension disabled:
+        # if self.use_hfe_extension:
+        #     self._leaf_filtering()
 
     def _inital_selection(self, paths, X):
         """First part of the feature selection algorithm."""
@@ -180,11 +187,12 @@ class SHSELSelector(EagerHierarchicalFeatureSelector):
                     node in self.representatives_
                     and self._relevance_values[node] >= average_relevance
                 ):
-                    if (
-                        self.use_hfe_extension is False
-                        or self._relevance_values[node] > 0.0
-                    ):
-                        updated_representatives.append(node)
+                    # HFE extension disabled:
+                    # if (
+                    #     self.use_hfe_extension is False
+                    #     or self._relevance_values[node] > 0.0
+                    # ):
+                    updated_representatives.append(node)
 
         self.representatives_ = list(set(updated_representatives))  # remove duplicates
 
@@ -192,49 +200,55 @@ class SHSELSelector(EagerHierarchicalFeatureSelector):
         values = information_gain(X, y)
         self._relevance_values = dict(zip(self._columns, values))
 
-    def _preprocess(self, X):
-        """Preprocess numerical data by summing up child values.
+    # The following are all HFE extension methods.
+    # Note: `_preprocess` below additionally has an argument-
+    # order bug (passing "ROOT" as X); fix when re-enabling HFE.
 
-        This is part of the HFE extension and only makes sense for
-        numerial data and not for binary data.
-        """
-        return compute_aggregated_values("ROOT", X, self._hierarchy_graph, self._columns)
-
-    def _leaf_filtering(self):
-        """Filtering representatives by removing leaves with low relevance.
-
-        This is part of the HFE extension proposed by Oudah and Henschel.
-        """
-        average_ig = statistics.mean(
-            [self._relevance_values[node] for node in self.representatives_]
-        )
-
-        leaves = self._get_leaves_in_incomplete_paths()
-
-        nodes_to_remove = [
-            leaf
-            for leaf in leaves
-            if self._relevance_values[leaf] < average_ig
-            or self._relevance_values[leaf] == 0
-        ]
-        updated_representatives = [
-            node for node in self.representatives_ if node not in nodes_to_remove
-        ]
-        self.representatives_ = updated_representatives
-
-    def _get_leaves_in_incomplete_paths(self):
-        """Select leaves of incomplete paths (part of HFE extension)"""
-        leaves = [
-            leaf
-            for leaf in get_leaves(self._hierarchy_graph)
-            if leaf in self.representatives_
-        ]
-
-        paths = get_paths(self._hierarchy_graph)
-        max_path_len = max([len(path) for path in paths])
-        selected_leaves = []
-        for leaf in leaves:
-            for path in paths:
-                if leaf in path and len(path) != max_path_len:
-                    selected_leaves.append(leaf)
-        return selected_leaves
+    # def _preprocess(self, X):
+    #     """Preprocess numerical data by summing up child values.
+    #
+    #     This is part of the HFE extension and only makes sense for
+    #     numerial data and not for binary data.
+    #     """
+    #     return compute_aggregated_values(
+    #         "ROOT", X, self._hierarchy_graph, self._columns
+    #     )
+    #
+    # def _leaf_filtering(self):
+    #     """Filtering representatives by removing leaves with low relevance.
+    #
+    #     This is part of the HFE extension proposed by Oudah and Henschel.
+    #     """
+    #     average_ig = statistics.mean(
+    #         [self._relevance_values[node] for node in self.representatives_]
+    #     )
+    #
+    #     leaves = self._get_leaves_in_incomplete_paths()
+    #
+    #     nodes_to_remove = [
+    #         leaf
+    #         for leaf in leaves
+    #         if self._relevance_values[leaf] < average_ig
+    #         or self._relevance_values[leaf] == 0
+    #     ]
+    #     updated_representatives = [
+    #         node for node in self.representatives_ if node not in nodes_to_remove
+    #     ]
+    #     self.representatives_ = updated_representatives
+    #
+    # def _get_leaves_in_incomplete_paths(self):
+    #     """Select leaves of incomplete paths (part of HFE extension)"""
+    #     leaves = [
+    #         leaf
+    #         for leaf in get_leaves(self._hierarchy_graph)
+    #         if leaf in self.representatives_
+    #     ]
+    #
+    #     paths = get_paths(self._hierarchy_graph)
+    #     max_path_len = max([len(path) for path in paths])
+    #     selected_leaves = []
+    #     for leaf in leaves:
+    #         for path in paths:
+    #             if leaf in path and len(path) != max_path_len:
+    #                 selected_leaves.append(leaf)
+    #     return selected_leaves

--- a/scihfs/tests/_estimators.py
+++ b/scihfs/tests/_estimators.py
@@ -1,0 +1,61 @@
+"""Estimator groupings used across the tests in this repository.
+
+In order to route the estimators to the correct tests, they are sorted based on
+their properties.
+
+- ``ALL_ESTIMATORS`` - they expose the full sklearn estimator surface, and can
+    be run through the sklearn conformance test suite. (Union of the eager and
+    lazy selectors, plus the base classes and the preprocessor.)
+- ``EAGER_SELECTORS`` - single pass fit().
+- ``LAZY_SELECTORS`` - fit_selector() with both X_train and X_test to fit per
+    test instance.
+
+Future work: Divide by filter/wrapper/embedded feature selection methods when
+the embedded methods also inherit from ClassifierMixin.
+"""
+
+from scihfs import (
+    EagerHierarchicalFeatureSelector,
+    HierarchicalEstimator,
+    HierarchicalPreprocessor,
+)
+from scihfs.selectors import (
+    HIP,
+    HNB,
+    MR,
+    RNB,
+    TAN,
+    BottomUpSelector,
+    GreedyTopDownSelector,
+    HieAODE,
+    HNBs,
+    SHSELSelector,
+    TopDownSelector,
+    TSELSelector,
+)
+
+ALL_ESTIMATORS = [
+    TSELSelector,
+    HierarchicalEstimator,
+    EagerHierarchicalFeatureSelector,
+    HierarchicalPreprocessor,
+    TopDownSelector,
+    SHSELSelector,
+    HNB,
+    HNBs,
+    RNB,
+    MR,
+    HIP,
+    BottomUpSelector,
+    GreedyTopDownSelector,
+]
+
+EAGER_SELECTORS = [
+    SHSELSelector,
+    TSELSelector,
+    GreedyTopDownSelector,
+    TopDownSelector,
+    BottomUpSelector,
+]
+
+LAZY_SELECTORS = [HIP, HNB, HNBs, RNB, MR, TAN, HieAODE]

--- a/scihfs/tests/conftest.py
+++ b/scihfs/tests/conftest.py
@@ -19,7 +19,7 @@ def data1(hierarchy1):
             [0, 1, 1, 1, 1],
             [1, 1, 1, 1, 1],
         ]
-    )
+    ).astype(bool)
     columns = get_columns_for_numpy_hierarchy(hierarchy1, X.shape[1])
     hierarchy = nx.to_numpy_array(hierarchy1)
     y = np.array([0, 0, 0, 0, 1])
@@ -36,7 +36,7 @@ def data1_2(hierarchy1_2):
             [0, 1, 1, 1, 1],
             [1, 1, 1, 1, 1],
         ]
-    )
+    ).astype(bool)
     columns = get_columns_for_numpy_hierarchy(hierarchy1_2, X.shape[1])
     hierarchy = nx.to_numpy_array(hierarchy1_2)
     y = np.array([0, 0, 0, 0, 1])
@@ -53,7 +53,7 @@ def data2(hierarchy2):
             [1, 0, 0, 0, 1],
             [1, 1, 0, 0, 0],
         ],
-    )
+    ).astype(bool)
     columns = get_columns_for_numpy_hierarchy(hierarchy2, X.shape[1])
     hierarchy = nx.to_numpy_array(hierarchy2)
     y = np.array([1, 0, 0, 1, 1])
@@ -70,7 +70,7 @@ def data2_1():
             [1, 0, 0, 0, 1],
             [1, 1, 0, 0, 0],
         ],
-    )
+    ).astype(bool)
     edges = [(0, 1), (1, 2), (1, 3)]
     hierarchy = nx.DiGraph(edges)
     hierarchy.add_node(4)
@@ -90,7 +90,7 @@ def data2_2():
             [1, 0, 0, 0, 1],
             [1, 1, 0, 0, 0],
         ],
-    )
+    ).astype(bool)
     edges = [(0, 1), (1, 2), (1, 3)]
     hierarchy = nx.DiGraph(edges)
     hierarchy.add_node(4)
@@ -111,7 +111,7 @@ def data3(hierarchy3):
             [1, 0, 0, 0, 1],
             [1, 1, 0, 0, 0],
         ],
-    )
+    ).astype(bool)
 
     columns = get_columns_for_numpy_hierarchy(hierarchy3, X.shape[1])
     hierarchy = nx.to_numpy_array(hierarchy3)
@@ -129,7 +129,7 @@ def data4():
             [1, 0, 0, 1, 0, 1, 0],
             [1, 1, 0, 0, 1, 1, 1],
         ],
-    )
+    ).astype(bool)
     edges = [(0, 1), (1, 2), (0, 3), (0, 4), (0, 5), (5, 6)]
     hierarchy = nx.DiGraph(edges)
     columns = get_columns_for_numpy_hierarchy(hierarchy, X.shape[1])
@@ -389,7 +389,7 @@ def result_hill_selection_bu():
 
 @pytest.fixture()
 def wrong_hierarchy_X():
-    X = np.array([[0, 0, 0], [0, 0, 0], [0, 0, 0]])
+    X = np.array([[0, 0, 0], [0, 0, 0], [0, 0, 0]]).astype(bool)
     hierarchy = nx.to_numpy_array(nx.DiGraph([(0, 1)]))
     columns = [0, 1]
     return (X, hierarchy, columns)
@@ -397,7 +397,7 @@ def wrong_hierarchy_X():
 
 @pytest.fixture()
 def wrong_hierarchy_X1():
-    X = np.array([[0, 0, 0], [0, 0, 0], [0, 0, 0]])
+    X = np.array([[0, 0, 0], [0, 0, 0], [0, 0, 0]]).astype(bool)
     hierarchy = nx.to_numpy_array(nx.DiGraph([(0, 1), (1, 2), (3, 4), (0, 5)]))
     columns = [0, 1, 2]
     return (X, hierarchy, columns)
@@ -603,11 +603,11 @@ def lazy_data1():
         (5, 11),
     ]
     hierarchy = nx.DiGraph(edges)
-    X_train = np.ones((2, len(hierarchy.nodes)))
+    X_train = np.ones((2, len(hierarchy.nodes))).astype(bool)
     y_train = np.array([0, 1])
     X_test = np.array(
         [[1, 0, 1, 1, 0, 0, 0, 1, 0, 1, 1, 0], [1, 0, 1, 1, 0, 0, 0, 1, 0, 1, 1, 0]]
-    )
+    ).astype(bool)
     y_test = np.array([1, 0])
     relevance = [0.25, 0.23, 0.38, 0.25, 0.28, 0.38, 0.26, 0.31, 0.26, 0.23, 0.21, 0.26]
 
@@ -624,9 +624,11 @@ def lazy_data1():
 @pytest.fixture()
 def lazy_data2():
     small_DAG = nx.to_numpy_array(nx.DiGraph([(0, 1), (0, 2), (1, 2), (1, 3)]))
-    train_x_data = np.array([[1, 1, 0, 1], [1, 0, 0, 0], [1, 1, 1, 0], [1, 1, 1, 1]])
+    train_x_data = np.array(
+        [[1, 1, 0, 1], [1, 0, 0, 0], [1, 1, 1, 0], [1, 1, 1, 1]]
+    ).astype(bool)
     train_y_data = np.array([0, 0, 1, 1])
-    test_x_data = np.array([[1, 1, 0, 0], [1, 1, 1, 0]])
+    test_x_data = np.array([[1, 1, 0, 0], [1, 1, 1, 0]]).astype(bool)
     test_y_data = np.array([1, 0])
     return (small_DAG, train_x_data, train_y_data, test_x_data, test_y_data)
 
@@ -635,7 +637,7 @@ def lazy_data2():
 def lazy_data3():
     edges = [(4, 0), (0, 3), (2, 3), (5, 2), (5, 1)]
     hierarchy = nx.DiGraph(edges)
-    X_train_ones = np.ones((9, len(hierarchy.nodes)))
+    X_train_ones = np.ones((9, len(hierarchy.nodes))).astype(bool)
     X_train = np.array(
         [
             [1, 1, 1, 1, 1, 1],
@@ -648,9 +650,9 @@ def lazy_data3():
             [1, 0, 0, 1, 1, 0],
             [0, 1, 0, 0, 0, 1],
         ]
-    )
+    ).astype(bool)
     y_train = np.array([0, 1, 1, 0, 1, 1, 0, 1, 1])
-    X_test = np.array([[0, 0, 1, 0, 1, 1], [0, 1, 1, 0, 1, 1]])
+    X_test = np.array([[0, 0, 1, 0, 1, 1], [0, 1, 1, 0, 1, 1]]).astype(bool)
     y_test = np.array([1, 0])
     resulted_features = np.array(
         [[0.0, 1.0, 1.0, 1.0, 1.0, 0.0], [0.0, 1.0, 1.0, 1.0, 1.0, 0.0]]

--- a/scihfs/tests/conftest.py
+++ b/scihfs/tests/conftest.py
@@ -138,21 +138,22 @@ def data4():
     return (X, y, hierarchy, columns)
 
 
-@pytest.fixture()
-def data_numerical(hierarchy1):
-    X = np.array(
-        [
-            [1, 6, 3, 0, 1],
-            [4, 7, 1, 7, 0],
-            [2, 2, 5, 4, 0],
-            [6, 0, 2, 0, 2],
-            [1, 4, 1, 0, 3],
-        ]
-    )
-    columns = get_columns_for_numpy_hierarchy(hierarchy1, X.shape[1])
-    hierarchy = nx.to_numpy_array(hierarchy1)
-    y = np.array([0, 0, 0, 0, 1])
-    return (X, y, hierarchy, columns)
+# The "numerical" dataset_type has been disabled, so the following fixture becomes obsolete.
+# @pytest.fixture()
+# def data_numerical(hierarchy1):
+#     X = np.array(
+#         [
+#             [1, 6, 3, 0, 1],
+#             [4, 7, 1, 7, 0],
+#             [2, 2, 5, 4, 0],
+#             [6, 0, 2, 0, 2],
+#             [1, 4, 1, 0, 3],
+#         ]
+#     )
+#     columns = get_columns_for_numpy_hierarchy(hierarchy1, X.shape[1])
+#     hierarchy = nx.to_numpy_array(hierarchy1)
+#     y = np.array([0, 0, 0, 0, 1])
+#     return (X, y, hierarchy, columns)
 
 
 @pytest.fixture()
@@ -412,47 +413,49 @@ def result_score_matrix1():
     )
 
 
-@pytest.fixture()
-def result_score_matrix_numerical():
-    return np.array(
-        [
-            [
-                1.6931471805599454,
-                1.5978370007556206,
-                1.241162056816888,
-                0,
-                1.0870113769896297,
-            ],
-            [
-                1.6931471805599454,
-                1.3513978868378886,
-                1.0512932943875506,
-                1.3136575588550417,
-                0,
-            ],
-            [
-                1.6931471805599454,
-                1.4307829160924541,
-                1.325422400434628,
-                1.2682639865946794,
-                0,
-            ],
-            [
-                1.6931471805599454,
-                1.1823215567939547,
-                1.1823215567939547,
-                0,
-                1.1823215567939547,
-            ],
-            [
-                1.6931471805599454,
-                1.4418327522790393,
-                1.1053605156578263,
-                0,
-                1.2876820724517808,
-            ],
-        ]
-    )
+# "numerical" dataset_type disabled; this expected log-normalized-score
+# fixture is commented out with the numerical tests for re-enablement.
+# @pytest.fixture()
+# def result_score_matrix_numerical():
+#     return np.array(
+#         [
+#             [
+#                 1.6931471805599454,
+#                 1.5978370007556206,
+#                 1.241162056816888,
+#                 0,
+#                 1.0870113769896297,
+#             ],
+#             [
+#                 1.6931471805599454,
+#                 1.3513978868378886,
+#                 1.0512932943875506,
+#                 1.3136575588550417,
+#                 0,
+#             ],
+#             [
+#                 1.6931471805599454,
+#                 1.4307829160924541,
+#                 1.325422400434628,
+#                 1.2682639865946794,
+#                 0,
+#             ],
+#             [
+#                 1.6931471805599454,
+#                 1.1823215567939547,
+#                 1.1823215567939547,
+#                 0,
+#                 1.1823215567939547,
+#             ],
+#             [
+#                 1.6931471805599454,
+#                 1.4418327522790393,
+#                 1.1053605156578263,
+#                 0,
+#                 1.2876820724517808,
+#             ],
+#         ]
+#     )
 
 
 @pytest.fixture()

--- a/scihfs/tests/conftest.py
+++ b/scihfs/tests/conftest.py
@@ -228,9 +228,10 @@ def result_shsel1(result_tsel1):
     return result_tsel1
 
 
-@pytest.fixture()
-def result_shsel_hfe1(result_shsel1):
-    return result_shsel1
+# HFE extension of SHSEL disabled.
+# @pytest.fixture()
+# def result_shsel_hfe1(result_shsel1):
+#     return result_shsel1
 
 
 @pytest.fixture()
@@ -248,34 +249,36 @@ def result_shsel2():
     return (result, support)
 
 
-@pytest.fixture()
-def result_shsel_hfe2():
-    result = np.array(
-        [
-            [0],
-            [1],
-            [1],
-            [0],
-            [0],
-        ],
-    )
-    support = np.array([False, False, True, False, False])
-    return (result, support)
+# HFE extension of SHSEL disabled.
+# @pytest.fixture()
+# def result_shsel_hfe2():
+#     result = np.array(
+#         [
+#             [0],
+#             [1],
+#             [1],
+#             [0],
+#             [0],
+#         ],
+#     )
+#     support = np.array([False, False, True, False, False])
+#     return (result, support)
 
 
-@pytest.fixture()
-def result_shsel_hfe4():
-    result = np.array(
-        [
-            [0, 1, 1],
-            [1, 0, 0],
-            [1, 1, 0],
-            [0, 1, 0],
-            [0, 1, 1],
-        ],
-    )
-    support = np.array([False, False, True, False, False, True, True])
-    return (result, support)
+# HFE extension of SHSEL disabled.
+# @pytest.fixture()
+# def result_shsel_hfe4():
+#     result = np.array(
+#         [
+#             [0, 1, 1],
+#             [1, 0, 0],
+#             [1, 1, 0],
+#             [0, 1, 0],
+#             [0, 1, 1],
+#         ],
+#     )
+#     support = np.array([False, False, True, False, False, True, True])
+#     return (result, support)
 
 
 @pytest.fixture()

--- a/scihfs/tests/test_common.py
+++ b/scihfs/tests/test_common.py
@@ -1,55 +1,54 @@
 import networkx as nx
+import numpy as np
 import pytest
-from sklearn.utils.estimator_checks import check_estimator
 
-from scihfs import (
-    EagerHierarchicalFeatureSelector,
-    HierarchicalEstimator,
-    HierarchicalPreprocessor,
-)
-from scihfs.selectors import (
-    HIP,
-    HNB,
-    MR,
-    RNB,
-    BottomUpSelector,
-    GreedyTopDownSelector,
-    HNBs,
-    SHSELSelector,
-    TopDownSelector,
-    TSELSelector,
-)
+from scihfs.tests._estimators import EAGER_SELECTORS, LAZY_SELECTORS
+
+# ---------------------------------------------------------------------------
+# TEMPORARY FILE CONTENT WARNING:
+#
+# At the moment, the scope of this file is only to test the rejection of
+# non-bool-dtype input to the selectors. All sklearn-related tests are in
+# test_sklearn_conformance.py for now.
+#
+# In the future, this file should contain all those tests that apply to
+# ALL estimators alike. Right now, a lot of these are scattered throughout
+# the respective test files for each estimator.
+# ---------------------------------------------------------------------------
+
+_HIERARCHY = nx.to_numpy_array(nx.DiGraph([(0, 1), (1, 2), (0, 3)]))
+_X_BOOL = np.array([[0, 1, 0, 1], [1, 0, 1, 0], [0, 0, 1, 1], [1, 1, 0, 0]], dtype=bool)
+_Y = np.array([0, 1, 0, 1])
+_REJECTED_DTYPES = [np.int8, np.int32, np.int64, np.float32, np.float64]
 
 
-@pytest.mark.parametrize(
-    "estimator",
-    [
-        TSELSelector,
-        HierarchicalEstimator,
-        EagerHierarchicalFeatureSelector,
-        pytest.param(
-            HierarchicalPreprocessor,
-            marks=pytest.mark.xfail(
-                strict=True,
-                reason=(
-                    "HierarchicalPreprocessor now requires bool-dtype input; "
-                    "sklearn's check_estimator suite feeds float arrays. "
-                    "Pending sum-propagation mode that will reopen numeric inputs."
-                ),
-            ),
-        ),
-        TopDownSelector,
-        SHSELSelector,
-        HNB,
-        HNBs,
-        RNB,
-        MR,
-        HIP,
-        BottomUpSelector,
-        GreedyTopDownSelector,
-    ],
-)
-def test_all_estimators(estimator):
-    hierarchy_graph = nx.DiGraph()
-    adj_matrix = nx.to_numpy_array(hierarchy_graph)
-    return check_estimator(estimator(adj_matrix))
+@pytest.mark.parametrize("dtype", _REJECTED_DTYPES)
+@pytest.mark.parametrize("Selector", EAGER_SELECTORS)
+def test_eager_selector_rejects_non_bool_X(Selector, dtype):
+    selector = Selector(_HIERARCHY)
+    with pytest.raises(ValueError, match="bool-dtype"):
+        selector.fit(_X_BOOL.astype(dtype), _Y)
+
+
+@pytest.mark.parametrize("dtype", _REJECTED_DTYPES)
+@pytest.mark.parametrize("Selector", LAZY_SELECTORS)
+def test_lazy_selector_fit_rejects_non_bool_X(Selector, dtype):
+    selector = Selector(_HIERARCHY)
+    with pytest.raises(ValueError, match="bool-dtype"):
+        selector.fit(_X_BOOL.astype(dtype), _Y)
+
+
+@pytest.mark.parametrize("dtype", _REJECTED_DTYPES)
+@pytest.mark.parametrize("Selector", LAZY_SELECTORS)
+def test_lazy_selector_fit_selector_rejects_non_bool_X_test(Selector, dtype):
+    selector = Selector(_HIERARCHY)
+    with pytest.raises(ValueError, match="bool-dtype"):
+        selector.fit_selector(X_train=_X_BOOL, y_train=_Y, X_test=_X_BOOL.astype(dtype))
+
+
+@pytest.mark.parametrize("dtype", _REJECTED_DTYPES)
+@pytest.mark.parametrize("Selector", LAZY_SELECTORS)
+def test_lazy_selector_fit_selector_rejects_non_bool_X_train(Selector, dtype):
+    selector = Selector(_HIERARCHY)
+    with pytest.raises(ValueError, match="bool-dtype"):
+        selector.fit_selector(X_train=_X_BOOL.astype(dtype), y_train=_Y, X_test=_X_BOOL)

--- a/scihfs/tests/test_helpers.py
+++ b/scihfs/tests/test_helpers.py
@@ -114,6 +114,12 @@ def test_compute_aggregated_values(data, result, request):
     data = request.getfixturevalue(data)
     result = request.getfixturevalue(result)
     X, _, hierarchy, columns = data
+    # Contract: the input is bool (binary features). Aggregation must COUNT the
+    # 'True' values per subtree, returning a compact uint32 count array.
+    assert X.dtype == np.bool_
     hierarchy = add_virtual_root_node(nx.DiGraph(hierarchy))
     X_transformed = compute_aggregated_values(X, hierarchy, columns)
+    assert X_transformed.dtype == np.uint32
     assert np.array_equal(X_transformed, result)
+    # The bool input is left untouched (a fresh integer working copy is built).
+    assert X.dtype == np.bool_

--- a/scihfs/tests/test_hie_aode.py
+++ b/scihfs/tests/test_hie_aode.py
@@ -1,9 +1,14 @@
 import networkx as nx
 import numpy as np
+import pytest
 
 from scihfs.selectors import HieAODE
 
 
+@pytest.mark.skip(
+    reason="HieAODE bool-dtype CPT-indexing fix owned by the dedicated "
+    "hie-aode branch; re-enable on merge."
+)
 def test_hie_aode(lazy_data2):
     small_DAG, train_x_data, train_y_data, test_x_data, _ = lazy_data2
     selector = HieAODE(hierarchy=small_DAG)

--- a/scihfs/tests/test_hill_climbing.py
+++ b/scihfs/tests/test_hill_climbing.py
@@ -3,6 +3,9 @@ import pytest
 
 from scihfs.selectors.hill_climbing import BottomUpSelector, TopDownSelector
 
+# The `dataset_type="numerical"` path is disabled (so is its initialization),
+# the two corresponding tests below are commented out.
+
 
 @pytest.mark.parametrize(
     "data",
@@ -12,7 +15,7 @@ def test_top_down_selection(data, result_hill_selection_td, request):
     data = request.getfixturevalue(data)
     X, y, hierarchy, columns = data
     expected, support = result_hill_selection_td
-    selector = TopDownSelector(hierarchy, dataset_type="binary")
+    selector = TopDownSelector(hierarchy)
     selector.fit(X, y, columns)
     X = selector.transform(X)
     assert np.array_equal(X, expected)
@@ -24,7 +27,7 @@ def test_top_down_selection(data, result_hill_selection_td, request):
 def test_bottom_up_selection(data1, result_hill_selection_bu):
     X, y, hierarchy, columns = data1
     expected, support, k = result_hill_selection_bu
-    selector = BottomUpSelector(hierarchy, k=k, dataset_type="binary")
+    selector = BottomUpSelector(hierarchy, k=k)
     selector.fit(X, y, columns)
     X = selector.transform(X)
     assert np.array_equal(X, expected)
@@ -33,16 +36,17 @@ def test_bottom_up_selection(data1, result_hill_selection_bu):
     assert np.array_equal(support_mask, support)
 
 
-def test_bottom_up_selection_numerical(data1, result_hill_selection_bu):
-    X, y, hierarchy, columns = data1
-    expected, support, k = result_hill_selection_bu
-    selector = BottomUpSelector(hierarchy, k=k, dataset_type="numerical")
-    selector.fit(X, y, columns)
-    X = selector.transform(X)
-    assert np.array_equal(X, expected)
-
-    support_mask = selector.get_support()
-    assert np.array_equal(support_mask, support)
+# Numerical input is currently not supported. Corresponding code is retained (but inactive) for future reintroduction.
+# def test_bottom_up_selection_numerical(data1, result_hill_selection_bu):
+#     X, y, hierarchy, columns = data1
+#     expected, support, k = result_hill_selection_bu
+#     selector = BottomUpSelector(hierarchy, k=k, dataset_type="numerical")
+#     selector.fit(X, y, columns)
+#     X = selector.transform(X)
+#     assert np.array_equal(X, expected)
+#
+#     support_mask = selector.get_support()
+#     assert np.array_equal(support_mask, support)
 
 
 @pytest.mark.parametrize(
@@ -59,22 +63,23 @@ def test_calculate_scores(data, result, request):
     X, y, hierarchy, columns = data
     score_matrix_expected = result
 
-    selector = TopDownSelector(hierarchy, dataset_type="binary")
+    selector = TopDownSelector(hierarchy)
     selector.fit(X, y, columns)
     score_matrix = selector._calculate_scores(X)
 
     assert np.array_equal(score_matrix, score_matrix_expected)
 
 
-def test_calculate_scores_numerical(data_numerical, result_score_matrix_numerical):
-    X, y, hierarchy, columns = data_numerical
-    score_matrix_expected = result_score_matrix_numerical
-
-    selector = TopDownSelector(hierarchy, dataset_type="numerical")
-    selector.fit(X, y, columns)
-    score_matrix = selector._calculate_scores(X)
-
-    assert np.array_equal(score_matrix, score_matrix_expected)
+# Numerical input is currently not supported. Corresponding code is retained (but inactive) for future reintroduction.
+# def test_calculate_scores_numerical(data_numerical, result_score_matrix_numerical):
+#     X, y, hierarchy, columns = data_numerical
+#     score_matrix_expected = result_score_matrix_numerical
+#
+#     selector = TopDownSelector(hierarchy, dataset_type="numerical")
+#     selector.fit(X, y, columns)
+#     score_matrix = selector._calculate_scores(X)
+#
+#     assert np.array_equal(score_matrix, score_matrix_expected)
 
 
 @pytest.mark.parametrize(

--- a/scihfs/tests/test_hill_climbing.py
+++ b/scihfs/tests/test_hill_climbing.py
@@ -97,7 +97,8 @@ def test_comparison_matrix(data, result, Selector, request):
     X, y, hierarchy, columns = data
     comparison_matrix_expected = result
 
-    selector = Selector(hierarchy)
+    kwargs = {"k": 3} if Selector is BottomUpSelector else {}
+    selector = Selector(hierarchy, **kwargs)
     selector.fit(X, y, columns)
     comparison_matrix = selector._comparison_matrix(columns)
 

--- a/scihfs/tests/test_shsel.py
+++ b/scihfs/tests/test_shsel.py
@@ -1,6 +1,8 @@
+import networkx as nx
 import numpy as np
 import pytest
 
+from scihfs.helpers import get_columns_for_numpy_hierarchy
 from scihfs.selectors import SHSELSelector
 
 
@@ -49,32 +51,59 @@ def test_SHSEL_selection_with_initial_selection(data, result, request):
     assert np.array_equal(support_mask, support)
 
 
-@pytest.mark.parametrize(
-    "data, result",
-    [
-        ("data1", "result_shsel_hfe1"),
-        ("data2", "result_shsel_hfe2"),
-        ("data4", "result_shsel_hfe4"),
-    ],
-)
-def test_leaf_filtering(data, result, request):
-    data = request.getfixturevalue(data)
-    result = request.getfixturevalue(result)
-    X, y, hierarchy, columns = data
-    expected, support = result
+# HFE extension disabled; the corresponding tests are
+# commented out (with their result_shsel_hfe* fixtures in conftest.py) and
+# kept for re-enablement when the extension returns.
+# @pytest.mark.parametrize(
+#     "data, result",
+#     [
+#         ("data1", "result_shsel_hfe1"),
+#         ("data2", "result_shsel_hfe2"),
+#         ("data4", "result_shsel_hfe4"),
+#     ],
+# )
+# def test_leaf_filtering(data, result, request):
+#     data = request.getfixturevalue(data)
+#     result = request.getfixturevalue(result)
+#     X, y, hierarchy, columns = data
+#     expected, support = result
+#     selector = SHSELSelector(
+#         hierarchy, use_hfe_extension=True, relevance_metric="Correlation"
+#     )
+#     selector.fit(X, y, columns)
+#     X = selector.transform(X)
+#     assert np.array_equal(X, expected)
+#
+#     support_mask = selector.get_support()
+#     assert np.array_equal(support_mask, support)
+#
+#
+# def test_fail_on_invalid_relevance_metric(data1):
+#     X, y, _, _ = data1
+#     selector = SHSELSelector(use_hfe_extension=True, relevance_metric="IG")
+#     with pytest.raises(ValueError):
+#         selector.fit(X, y)
+
+
+def test_SHSEL_selection_correlation_on_bool():
+    """The non-HFE (Pearson) Correlation path works on bool input."""
+    edges = [(0, 1), (1, 2), (0, 3)]
+    hierarchy = nx.to_numpy_array(nx.DiGraph(edges))
+    columns = get_columns_for_numpy_hierarchy(nx.DiGraph(edges), 4)
+    X = np.array(
+        [[1, 1, 1, 0], [1, 1, 0, 1], [1, 0, 0, 1], [1, 1, 0, 0], [0, 0, 0, 0]],
+        dtype=bool,
+    )
+    y = np.array([1, 0, 0, 1, 0])
+
     selector = SHSELSelector(
-        hierarchy, use_hfe_extension=True, relevance_metric="Correlation"
+        hierarchy, relevance_metric="Correlation", similarity_threshold=0.8
     )
     selector.fit(X, y, columns)
-    X = selector.transform(X)
-    assert np.array_equal(X, expected)
+    X_transformed = selector.transform(X)
 
-    support_mask = selector.get_support()
-    assert np.array_equal(support_mask, support)
-
-
-def test_fail_on_invalid_relevance_metric(data1):
-    X, y, _, _ = data1
-    selector = SHSELSelector(use_hfe_extension=True, relevance_metric="IG")
-    with pytest.raises(ValueError):
-        selector.fit(X, y)
+    assert np.array_equal(selector.get_support(), np.array([False, True, True, True]))
+    expected = np.array(
+        [[1, 1, 0], [1, 0, 1], [0, 0, 1], [1, 0, 0], [0, 0, 0]], dtype=bool
+    )
+    assert np.array_equal(X_transformed, expected)

--- a/scihfs/tests/test_sklearn_conformance.py
+++ b/scihfs/tests/test_sklearn_conformance.py
@@ -1,0 +1,873 @@
+"""sklearn conformance tests for the scihfs estimators, semi-automatically
+generated.
+
+Two complementary test sections, both following the "check x estimator"
+matrix pattern mirroring the shape of sklearn's parametrize_with_checks.
+
+Section 1: Core sklearn conformance via check_estimator.
+
+    ``test_all_estimators`` runs sklearn's ``check_estimator``. The suite
+    partially feeds non-binary float/sparse data, which the current strict
+    bool-dtype contract rejects. Those tests should not fail the entire suite,
+    thus are listed under the ``_EXPECTED_FAILED_CHECKS`` and are exempted
+    from the pass/fail logic.
+    The remaining checks are dtype-independent and should pass as expected.
+
+Section 2: Sklearn-adjacent conformance.
+
+    Addresses those ``check_estimator`` checks that fail because of the
+    current strict bool-dtype enforcement.
+
+    Section 2A:
+        Reimplements the corresponding sklearn checks with identical logic, but
+        changes the input to random bool data (instead of random non-bool data).
+
+    Section 2B:
+        'Best effort' to reimplement the corresponding sklearn checks' logic, but
+        required adaptation in the logic to fit the bool-dtype data format
+        (or a bool-applicable subset of the original logic).
+
+    Section 2C:
+        Stubs ('pass') for those sklearn checks that fundamentally require
+        different data and cannot be faithfully recreated.
+"""
+
+import pickle
+import re
+from copy import deepcopy
+from functools import partial
+from inspect import signature
+
+import joblib
+import networkx as nx
+import numpy as np
+import pytest
+import scipy.sparse as sparse
+from sklearn.base import clone
+from sklearn.exceptions import NotFittedError
+from sklearn.model_selection import ShuffleSplit
+from sklearn.pipeline import make_pipeline
+from sklearn.utils import _safe_indexing, get_tags
+from sklearn.utils._testing import (
+    assert_allclose,
+    assert_allclose_dense_sparse,
+    create_memmap_backed_data,
+    set_random_state,
+)
+from sklearn.utils.estimator_checks import (
+    _apply_on_subsets,
+    _enforce_estimator_tags_X,
+    _enforce_estimator_tags_y,
+    _is_public_parameter,
+    _NotAnArray,
+    check_estimator,
+)
+from sklearn.utils.metaestimators import _safe_split
+from sklearn.utils.validation import check_is_fitted
+
+from scihfs.tests._estimators import ALL_ESTIMATORS
+
+# ---------------------------------------------------------------------------
+# 1. sklearn check_estimator with the contract-incompatible checks declared.
+# ---------------------------------------------------------------------------
+
+# Shared reason for the expected-failed checks: every scihfs estimator now
+# enforces bool-dtype input, but sklearn's check_estimator suite feeds
+# numeric (float) / sparse arrays, so the dtype-dependent checks are expected to
+# fail. Re-opens once numeric input will be supported.
+_BOOL_DTYPE_XFAIL_REASON = (
+    "enforces bool-dtype input; sklearn check_estimator feeds numeric arrays."
+)
+
+# The exact set of check_estimator checks that fail because scihfs enforces
+# bool-dtype input. Declaring them here (instead of strict-xfailing the whole
+# row) lets the ~17 dtype-independent conformance checks actually run and pass,
+# while these are recorded as expected failures. With on_fail='raise' (the
+# default), any NEW failure outside this set fails the test as a real regression.
+#
+# All ALL_ESTIMATORS share this identical set. It is sklearn-version-specific:
+# generated against sklearn 1.8.0. If sklearn is upgraded the set may drift --
+# re-enumerate (XPASS raises if a listed check actually starts passing).
+_EXPECTED_FAILED_CHECKS = {
+    name: _BOOL_DTYPE_XFAIL_REASON
+    for name in (
+        "check_dict_unchanged",
+        "check_dont_overwrite_parameters",
+        "check_dtype_object",
+        "check_estimator_sparse_array",
+        "check_estimator_sparse_matrix",
+        "check_estimator_sparse_tag",
+        "check_estimators_dtypes",
+        "check_estimators_fit_returns_self",
+        "check_estimators_nan_inf",
+        "check_estimators_overwrite_params",
+        "check_estimators_pickle",
+        "check_f_contiguous_array_estimator",
+        "check_fit2d_1feature",
+        "check_fit2d_1sample",
+        "check_fit2d_predict1d",
+        "check_fit_check_is_fitted",
+        "check_fit_idempotent",
+        "check_fit_score_takes_y",
+        "check_methods_sample_order_invariance",
+        "check_methods_subset_invariance",
+        "check_n_features_in",
+        "check_n_features_in_after_fitting",
+        "check_pipeline_consistency",
+        "check_positive_only_tag_during_fit",
+        "check_readonly_memmap_input",
+        "check_transformer_data_not_an_array",
+        "check_transformer_general",
+        "check_transformer_preserve_dtypes",
+    )
+}
+
+
+@pytest.mark.parametrize("estimator", ALL_ESTIMATORS)
+def test_all_estimators(estimator):
+    hierarchy_graph = nx.DiGraph()
+    adj_matrix = nx.to_numpy_array(hierarchy_graph)
+    check_estimator(
+        estimator(adj_matrix),
+        expected_failed_checks=_EXPECTED_FAILED_CHECKS,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Positive conformance on contract-compliant (bool) data.
+#
+# These re-implement individual check_estimator checks (sklearn names + logic)
+# but feed bool data so the behaviour runs and passes. Three groups:
+#
+#   Section 2A  -- dtype-independent invariants whose sklearn logic runs
+#                 essentially verbatim once bool data is supplied; they fail
+#                 under check_estimator only because the float data is rejected
+#                 at the bool-dtype gate. Covers the generic invariants plus the
+#                 shape edge cases, is-fitted, fit/score signature, sample-order
+#                 / subset invariance, pipeline consistency, list input and
+#                 dict-unchanged. The only deviations are the input data (bool)
+#                 and its width (matched to the hierarchy -- a couple of checks
+#                 that fix the feature count use a smaller hierarchy).
+#   Section 2B -- checks that probe a specific input *form* or data property
+#                 (sparse container, readonly memmap, F-contiguous layout,
+#                 non-finite values, dtype preservation, transformer
+#                 fit_transform consistency).
+#   Section 2C -- checks whose intent fundamentally requires non-bool input
+#                 (object dtype, multiple numeric dtypes, negative values), so
+#                 they cannot run under the contract. Kept as name + ``pass``
+#                 stubs.
+# ---------------------------------------------------------------------------
+
+_HIERARCHY = nx.to_numpy_array(nx.DiGraph([(0, 1), (1, 2), (0, 3)]))
+_N_FEATURES = _HIERARCHY.shape[0]
+
+
+def _binary_Xy(n_samples, random_state=0):
+    """Bool X (width-matched to the hierarchy) and a binary y.
+
+    The bool/width-matched stand-in for the float data sklearn's checks
+    generate: same role, but contract-compliant and shaped to the hierarchy.
+    """
+    rng = np.random.RandomState(random_state)
+    X = rng.randint(0, 2, size=(n_samples, _N_FEATURES)).astype(bool)
+    y = rng.randint(0, 2, size=n_samples)
+    return X, y
+
+
+def _fit_passes_or_matches(estimator, X, y, patterns):
+    """Mirror sklearn's raises(ValueError, match=patterns, may_pass=True).
+
+    fit either succeeds, or raises a ValueError whose message matches one of the
+    patterns; any other outcome fails.
+    """
+    try:
+        estimator.fit(X, y)
+    except ValueError as e:
+        assert any(
+            re.search(p, str(e)) for p in patterns
+        ), f"fit raised a ValueError not matching {patterns}: {e}"
+
+
+# ---------------------------------------------------------------------------
+# Section 2A:
+# Reimplements the corresponding sklearn checks with identical logic, but
+# changes the input to random bool data (instead of random non-bool data).
+# ---------------------------------------------------------------------------
+
+
+def check_estimators_fit_returns_self(name, estimator_orig):
+    """Check if self is returned when calling fit."""
+    X, y = _binary_Xy(n_samples=21)
+    X = _enforce_estimator_tags_X(estimator_orig, X)
+
+    estimator = clone(estimator_orig)
+    y = _enforce_estimator_tags_y(estimator, y)
+
+    set_random_state(estimator)
+    assert estimator.fit(X, y) is estimator
+
+
+def check_n_features_in(name, estimator_orig):
+    # Make sure that n_features_in_ doesn't exist until fit is called, and that
+    # its value is correct.
+    estimator = clone(estimator_orig)
+    set_random_state(estimator)
+
+    X, y = _binary_Xy(n_samples=100)
+    X = _enforce_estimator_tags_X(estimator, X)
+    y = _enforce_estimator_tags_y(estimator, y)
+
+    assert not hasattr(estimator, "n_features_in_")
+    estimator.fit(X, y)
+    assert hasattr(estimator, "n_features_in_")
+    assert estimator.n_features_in_ == X.shape[1]
+
+
+def check_n_features_in_after_fitting(name, estimator_orig):
+    # Make sure n_features_in_ is set after fitting and that the prediction
+    # methods reject inputs with the wrong number of features.
+    tags = get_tags(estimator_orig)
+    is_supported_X_types = tags.input_tags.two_d_array or tags.input_tags.categorical
+    if not is_supported_X_types or tags.no_validation:
+        return
+
+    estimator = clone(estimator_orig)
+    set_random_state(estimator)
+
+    X, y = _binary_Xy(n_samples=15)
+    X = _enforce_estimator_tags_X(estimator, X)
+    y = _enforce_estimator_tags_y(estimator, y)
+
+    estimator.fit(X, y)
+    assert hasattr(estimator, "n_features_in_")
+    assert estimator.n_features_in_ == X.shape[1]
+
+    check_methods = [
+        "predict",
+        "transform",
+        "decision_function",
+        "predict_proba",
+        "score",
+    ]
+    X_bad = X[:, [1]]
+    msg = f"X has 1 features, but \\w+ is expecting {X.shape[1]} features as input"
+    for method in check_methods:
+        if not hasattr(estimator, method):
+            continue
+        callable_method = getattr(estimator, method)
+        if method == "score":
+            callable_method = partial(callable_method, y=y)
+        with pytest.raises(ValueError, match=msg):
+            callable_method(X_bad)
+
+
+def check_estimators_pickle(name, estimator_orig):
+    """Test that we can pickle all estimators."""
+    check_methods = ["predict", "transform", "decision_function", "predict_proba"]
+
+    X, y = _binary_Xy(n_samples=30)
+    X = _enforce_estimator_tags_X(estimator_orig, X)
+
+    estimator = clone(estimator_orig)
+    y = _enforce_estimator_tags_y(estimator, y)
+
+    set_random_state(estimator)
+    estimator.fit(X, y)
+
+    unpickled_estimator = pickle.loads(pickle.dumps(estimator))
+
+    result = {
+        method: getattr(estimator, method)(X)
+        for method in check_methods
+        if hasattr(estimator, method)
+    }
+    for method in result:
+        unpickled_result = getattr(unpickled_estimator, method)(X)
+        assert_allclose_dense_sparse(result[method], unpickled_result)
+
+
+def check_fit_idempotent(name, estimator_orig):
+    # Check that est.fit(X).transform(X) is the same as est.fit(X).fit(X)
+    # .transform(X), via the public methods.
+    check_methods = ["predict", "transform", "decision_function", "predict_proba"]
+
+    estimator = clone(estimator_orig)
+    set_random_state(estimator)
+
+    X, y = _binary_Xy(n_samples=100)
+    X = _enforce_estimator_tags_X(estimator, X)
+    y = _enforce_estimator_tags_y(estimator, y)
+
+    rng = np.random.RandomState(0)
+    train, test = next(ShuffleSplit(test_size=0.2, random_state=rng).split(X))
+    X_train, y_train = _safe_split(estimator, X, y, train)
+    X_test, _ = _safe_split(estimator, X, y, test, train)
+
+    # Fit for the first time
+    estimator.fit(X_train, y_train)
+
+    result = {
+        method: getattr(estimator, method)(X_test)
+        for method in check_methods
+        if hasattr(estimator, method)
+    }
+
+    # Fit again
+    set_random_state(estimator)
+    estimator.fit(X_train, y_train)
+
+    for method in check_methods:
+        if hasattr(estimator, method):
+            new_result = getattr(estimator, method)(X_test)
+            if hasattr(new_result, "dtype") and np.issubdtype(
+                new_result.dtype, np.floating
+            ):
+                tol = 2 * np.finfo(new_result.dtype).eps
+            else:
+                tol = 2 * np.finfo(np.float64).eps
+            assert_allclose_dense_sparse(
+                result[method],
+                new_result,
+                atol=max(tol, 1e-9),
+                rtol=max(tol, 1e-7),
+                err_msg=f"Idempotency check failed for method {method}",
+            )
+
+
+def check_dont_overwrite_parameters(name, estimator_orig):
+    # check that fit method only changes or sets private attributes
+    estimator = clone(estimator_orig)
+    X, y = _binary_Xy(n_samples=20)
+    X = _enforce_estimator_tags_X(estimator_orig, X)
+    y = _enforce_estimator_tags_y(estimator, y)
+
+    set_random_state(estimator, 1)
+    dict_before_fit = estimator.__dict__.copy()
+    estimator.fit(X, y)
+
+    dict_after_fit = estimator.__dict__
+
+    public_keys_after_fit = [
+        key for key in dict_after_fit.keys() if _is_public_parameter(key)
+    ]
+
+    attrs_added_by_fit = [
+        key for key in public_keys_after_fit if key not in dict_before_fit.keys()
+    ]
+    assert not attrs_added_by_fit, (
+        "Estimator adds public attribute(s) during the fit method. Estimators"
+        " are only allowed to add private attributes either started with _ or"
+        " ended with _ but %s added" % ", ".join(attrs_added_by_fit)
+    )
+
+    attrs_changed_by_fit = [
+        key
+        for key in public_keys_after_fit
+        if (dict_before_fit[key] is not dict_after_fit[key])
+    ]
+    assert not attrs_changed_by_fit, (
+        "Estimator changes public attribute(s) during the fit method. Estimators"
+        " are only allowed to change attributes started or ended with _, but"
+        " %s changed" % ", ".join(attrs_changed_by_fit)
+    )
+
+
+def check_estimators_overwrite_params(name, estimator_orig):
+    X, y = _binary_Xy(n_samples=21)
+    X = _enforce_estimator_tags_X(estimator_orig, X)
+    estimator = clone(estimator_orig)
+    y = _enforce_estimator_tags_y(estimator, y)
+
+    set_random_state(estimator)
+
+    # Make a physical copy of the original estimator parameters before fitting.
+    params = estimator.get_params()
+    original_params = deepcopy(params)
+
+    estimator.fit(X, y)
+
+    # Compare the state of the model parameters with the original parameters
+    new_params = estimator.get_params()
+    for param_name, original_value in original_params.items():
+        new_value = new_params[param_name]
+        assert joblib.hash(new_value) == joblib.hash(original_value), (
+            "Estimator %s should not change or mutate the parameter %s from %s"
+            " to %s during fit." % (name, param_name, original_value, new_value)
+        )
+
+
+def check_fit2d_1feature(name, estimator_orig):
+    # Fitting a 2d array with a single feature works or gives an informative
+    # message. scihfs ties the feature count to the hierarchy, so the 1-feature
+    # fit is run against a width-matched 1-node hierarchy.
+    rnd = np.random.RandomState(0)
+    X = rnd.randint(0, 2, size=(10, 1)).astype(bool)
+    X = _enforce_estimator_tags_X(estimator_orig, X)
+    y = X[:, 0].astype(int)
+    estimator = type(estimator_orig)(np.zeros((1, 1)))
+    y = _enforce_estimator_tags_y(estimator, y)
+    set_random_state(estimator, 1)
+
+    msgs = [r"1 feature\(s\)", "n_features = 1", "n_features=1"]
+    _fit_passes_or_matches(estimator, X, y, msgs)
+
+
+def check_fit2d_1sample(name, estimator_orig):
+    # Fitting a 2d array with a single sample works or gives an informative
+    # message about the number of samples / classes.
+    rnd = np.random.RandomState(0)
+    X = rnd.randint(0, 2, size=(1, _N_FEATURES)).astype(bool)
+    X = _enforce_estimator_tags_X(estimator_orig, X)
+    y = X[:, 0].astype(int)
+    estimator = clone(estimator_orig)
+    y = _enforce_estimator_tags_y(estimator, y)
+    set_random_state(estimator, 1)
+
+    msgs = [
+        "1 sample",
+        "n_samples = 1",
+        "n_samples=1",
+        "one sample",
+        "1 class",
+        "one class",
+    ]
+    _fit_passes_or_matches(estimator, X, y, msgs)
+
+
+def check_fit2d_predict1d(name, estimator_orig):
+    # Fit a 2d array, then call the prediction methods with a 1d array.
+    X, y = _binary_Xy(n_samples=20)
+    X = _enforce_estimator_tags_X(estimator_orig, X)
+    estimator = clone(estimator_orig)
+    y = _enforce_estimator_tags_y(estimator, y)
+    set_random_state(estimator, 1)
+    estimator.fit(X, y)
+
+    for method in ["predict", "transform", "decision_function", "predict_proba"]:
+        if hasattr(estimator, method):
+            with pytest.raises(ValueError, match="Reshape your data"):
+                getattr(estimator, method)(X[0])
+
+
+def check_fit_check_is_fitted(name, estimator_orig):
+    # check_is_fitted must fail before fit and pass after.
+    estimator = clone(estimator_orig)
+    set_random_state(estimator)
+    X, y = _binary_Xy(n_samples=100)
+    X = _enforce_estimator_tags_X(estimator, X)
+    y = _enforce_estimator_tags_y(estimator, y)
+
+    if get_tags(estimator).requires_fit:
+        with pytest.raises(NotFittedError):
+            check_is_fitted(estimator)
+    estimator.fit(X, y)
+    check_is_fitted(estimator)  # must not raise
+
+
+def check_fit_score_takes_y(name, estimator_orig):
+    # All estimators must accept an optional y in fit/score so they compose in
+    # pipelines.
+    X, y = _binary_Xy(n_samples=30)
+    X = _enforce_estimator_tags_X(estimator_orig, X)
+    estimator = clone(estimator_orig)
+    y = _enforce_estimator_tags_y(estimator, y)
+    set_random_state(estimator)
+
+    funcs = ["fit", "score", "partial_fit", "fit_predict", "fit_transform"]
+    for func_name in funcs:
+        func = getattr(estimator, func_name, None)
+        if func is not None:
+            func(X, y)
+            args = [p.name for p in signature(func).parameters.values()]
+            if args[0] == "self":
+                args = args[1:]
+            assert args[1] in [
+                "y",
+                "Y",
+            ], "Expected y or Y as second argument for method %s of %s. Got %r." % (
+                func_name,
+                type(estimator).__name__,
+                args,
+            )
+
+
+def check_methods_sample_order_invariance(name, estimator_orig):
+    # Methods give invariant results under a permutation of the sample order.
+    X, y = _binary_Xy(n_samples=20)
+    X = _enforce_estimator_tags_X(estimator_orig, X)
+    estimator = clone(estimator_orig)
+    y = _enforce_estimator_tags_y(estimator, y)
+    set_random_state(estimator, 1)
+    estimator.fit(X, y)
+
+    idx = np.random.permutation(X.shape[0])
+    for method in ["predict", "transform", "decision_function", "predict_proba"]:
+        if hasattr(estimator, method):
+            assert_allclose_dense_sparse(
+                _safe_indexing(getattr(estimator, method)(X), idx),
+                getattr(estimator, method)(_safe_indexing(X, idx)),
+                atol=1e-9,
+                err_msg=f"{method} of {name} is not sample-order invariant.",
+            )
+
+
+def check_methods_subset_invariance(name, estimator_orig):
+    # Methods give invariant results on a subset vs the whole set.
+    X, y = _binary_Xy(n_samples=20)
+    X = _enforce_estimator_tags_X(estimator_orig, X)
+    estimator = clone(estimator_orig)
+    y = _enforce_estimator_tags_y(estimator, y)
+    set_random_state(estimator, 1)
+    estimator.fit(X, y)
+
+    for method in ["predict", "transform", "decision_function", "predict_proba"]:
+        if hasattr(estimator, method):
+            result_full, result_by_batch = _apply_on_subsets(
+                getattr(estimator, method), X
+            )
+            assert_allclose(
+                result_full,
+                result_by_batch,
+                atol=1e-7,
+                err_msg=f"{method} of {name} is not subset invariant.",
+            )
+
+
+def check_pipeline_consistency(name, estimator_orig):
+    # make_pipeline(est) gives the same result as est on its own.
+    if get_tags(estimator_orig).non_deterministic:
+        pytest.skip(name + " is non deterministic")
+
+    X, y = _binary_Xy(n_samples=30)
+    X = _enforce_estimator_tags_X(estimator_orig, X)
+    estimator = clone(estimator_orig)
+    y = _enforce_estimator_tags_y(estimator, y)
+    set_random_state(estimator)
+    pipeline = make_pipeline(estimator)
+    estimator.fit(X, y)
+    pipeline.fit(X, y)
+
+    for func_name in ["score", "fit_transform"]:
+        func = getattr(estimator, func_name, None)
+        if func is not None:
+            result = func(X, y)
+            result_pipe = getattr(pipeline, func_name)(X, y)
+            assert_allclose_dense_sparse(result, result_pipe)
+
+
+def check_transformer_data_not_an_array(name, transformer_orig):
+    # The transformer behaves the same when X is not an ndarray (a _NotAnArray
+    # wrapper, or a plain list).
+    X, y = _binary_Xy(n_samples=30)
+    X = _enforce_estimator_tags_X(transformer_orig, X)
+    _check_transformer_binary(
+        name, transformer_orig, _NotAnArray(X), _NotAnArray(np.asarray(y))
+    )
+    _check_transformer_binary(name, transformer_orig, X.tolist(), y.tolist())
+
+
+def check_dict_unchanged(name, estimator_orig):
+    # The prediction methods must not mutate the estimator's __dict__.
+    X, y = _binary_Xy(n_samples=20)
+    X = _enforce_estimator_tags_X(estimator_orig, X)
+    estimator = clone(estimator_orig)
+    y = _enforce_estimator_tags_y(estimator, y)
+    set_random_state(estimator, 1)
+    estimator.fit(X, y)
+
+    for method in ["predict", "transform", "decision_function", "predict_proba"]:
+        if hasattr(estimator, method):
+            dict_before = estimator.__dict__.copy()
+            getattr(estimator, method)(X)
+            assert (
+                estimator.__dict__ == dict_before
+            ), f"Estimator changes __dict__ during {method}"
+
+
+_SECTION_A_CHECKS = [
+    check_estimators_fit_returns_self,
+    check_n_features_in,
+    check_n_features_in_after_fitting,
+    check_estimators_pickle,
+    check_fit_idempotent,
+    check_dont_overwrite_parameters,
+    check_estimators_overwrite_params,
+    check_fit2d_1feature,
+    check_fit2d_1sample,
+    check_fit2d_predict1d,
+    check_fit_check_is_fitted,
+    check_fit_score_takes_y,
+    check_methods_sample_order_invariance,
+    check_methods_subset_invariance,
+    check_pipeline_consistency,
+    check_transformer_data_not_an_array,
+    check_dict_unchanged,
+]
+
+
+# ---------------------------------------------------------------------------
+# Section 2B:
+# 'Best effort' to reimplement the corresponding sklearn checks' logic, but
+# required adaptation in the logic to fit the bool-dtype data format (or a
+# bool-applicable subset of the original logic).
+# ---------------------------------------------------------------------------
+
+
+def _check_estimator_sparse_container(name, estimator_orig, sparse_type):
+    """Mirror sklearn's sparse-container check on bool data.
+
+    scihfs declares input_tags.sparse=True and validates with accept_sparse,
+    so fitting sparse *bool* input must succeed (sklearn's check feeds sparse
+    float, which the contract rejects -- see check_estimator_sparse_array in
+    _EXPECTED_FAILED_CHECKS).
+    """
+    X, y = _binary_Xy(n_samples=40)
+    X = _enforce_estimator_tags_X(estimator_orig, X)
+    X = sparse_type(X)
+
+    estimator = clone(estimator_orig)
+    y = _enforce_estimator_tags_y(estimator, y)
+    set_random_state(estimator)
+
+    estimator.fit(X, y)
+    if hasattr(estimator, "predict"):
+        assert estimator.predict(X).shape[0] == X.shape[0]
+    if hasattr(estimator, "transform"):
+        assert estimator.transform(X).shape[0] == X.shape[0]
+
+
+def check_estimator_sparse_array(name, estimator_orig):
+    _check_estimator_sparse_container(name, estimator_orig, sparse.csr_array)
+
+
+def check_estimator_sparse_matrix(name, estimator_orig):
+    _check_estimator_sparse_container(name, estimator_orig, sparse.csr_matrix)
+
+
+def check_estimator_sparse_tag(name, estimator_orig):
+    """Check the input_tags.sparse tag is consistent with fit behaviour."""
+    estimator = clone(estimator_orig)
+
+    X, y = _binary_Xy(n_samples=40)
+    X = _enforce_estimator_tags_X(estimator, X)
+    y = _enforce_estimator_tags_y(estimator, y)
+    X = sparse.csr_array(X)
+
+    tags = get_tags(estimator)
+    if tags.input_tags.sparse:
+        try:
+            estimator.fit(X, y)  # should pass
+        except Exception as e:
+            raise AssertionError(
+                f"Estimator {name} raised an exception. The tag "
+                f"self.input_tags.sparse={tags.input_tags.sparse} might not be "
+                "consistent with the estimator's ability to handle sparse data."
+            ) from e
+    else:
+        # No scihfs estimator declares sparse=False, but keep the branch
+        # faithful to sklearn: it must then reject sparse with a clear message.
+        try:
+            estimator.fit(X, y)
+        except (ValueError, TypeError) as e:
+            if re.search("[Ss]parse", str(e)):
+                return
+            raise AssertionError(
+                f"Estimator {name} failed on sparse data but the error did not "
+                "state that sparse input is unsupported."
+            ) from e
+        raise AssertionError(
+            f"Estimator {name} did not fail on sparse data despite "
+            f"self.input_tags.sparse={tags.input_tags.sparse}."
+        )
+
+
+def check_readonly_memmap_input(name, estimator_orig):
+    """Check that the estimator can handle readonly memmap backed data."""
+    X, y = _binary_Xy(n_samples=21)
+    X = _enforce_estimator_tags_X(estimator_orig, X)
+
+    estimator = clone(estimator_orig)
+    y = _enforce_estimator_tags_y(estimator, y)
+
+    X, y = create_memmap_backed_data([X, y])
+
+    set_random_state(estimator)
+    assert estimator.fit(X, y) is estimator
+
+
+def check_f_contiguous_array_estimator(name, estimator_orig):
+    # Non-regression test for F-contiguous input handling.
+    estimator = clone(estimator_orig)
+
+    X, y = _binary_Xy(n_samples=20)
+    X = _enforce_estimator_tags_X(estimator_orig, X)
+    X = np.asfortranarray(X)
+    y = _enforce_estimator_tags_y(estimator_orig, y)
+
+    estimator.fit(X, y)
+
+    if hasattr(estimator, "transform"):
+        estimator.transform(X)
+    if hasattr(estimator, "predict"):
+        estimator.predict(X)
+
+
+def check_transformer_general(name, transformer_orig):
+    X, y = _binary_Xy(n_samples=30)
+    X = _enforce_estimator_tags_X(transformer_orig, X)
+    _check_transformer_binary(name, transformer_orig, X, y)
+
+
+def _check_transformer_binary(name, transformer_orig, X, y):
+    # The bool-compatible core of sklearn's _check_transformer: fit_transform
+    # equals fit().transform(), shapes are consistent, and transform rejects a
+    # wrong feature count. The dtype-preservation parts are omitted (they need
+    # float input -- see check_transformer_preserve_dtypes).
+    n_samples, n_features = np.asarray(X).shape
+    transformer = clone(transformer_orig)
+    set_random_state(transformer)
+
+    transformer.fit(X, y)
+    # fit_transform should work on a non-fitted estimator
+    transformer_clone = clone(transformer)
+    X_pred = transformer_clone.fit_transform(X, y=y)
+    assert X_pred.shape[0] == n_samples
+
+    if hasattr(transformer, "transform"):
+        X_pred2 = transformer.transform(X)
+        X_pred3 = transformer.fit_transform(X, y=y)
+
+        if get_tags(transformer_orig).non_deterministic:
+            pytest.skip(name + " is non deterministic")
+
+        assert_allclose_dense_sparse(
+            X_pred,
+            X_pred2,
+            atol=1e-2,
+            err_msg=f"fit_transform and transform outcomes not consistent in {name}",
+        )
+        assert_allclose_dense_sparse(
+            X_pred,
+            X_pred3,
+            atol=1e-2,
+            err_msg=f"consecutive fit_transform outcomes not consistent in {name}",
+        )
+        assert X_pred2.shape[0] == n_samples
+        assert X_pred3.shape[0] == n_samples
+
+        if (
+            hasattr(X, "shape")
+            and get_tags(transformer).requires_fit
+            and X.ndim == 2
+            and X.shape[1] > 1
+        ):
+            with pytest.raises(ValueError):
+                transformer.transform(X[:, :-1])
+
+
+def check_estimators_nan_inf(name, estimator_orig):
+    # Checks that the estimator rejects NaN/inf. A bool array cannot hold NaN or
+    # inf, so -- like sklearn -- this necessarily uses non-finite *float* input;
+    # scihfs's validate_data finiteness check fires before the bool-dtype gate,
+    # so the rejection is genuinely about non-finiteness (message matches
+    # inf/NaN). The finite baseline is fitted on bool (float would be rejected
+    # for dtype before its finiteness ever mattered).
+    X_train_finite, _ = _binary_Xy(n_samples=10)
+    rnd = np.random.RandomState(0)
+    X_train_nan = rnd.uniform(size=(10, _N_FEATURES))
+    X_train_nan[0, 0] = np.nan
+    X_train_inf = rnd.uniform(size=(10, _N_FEATURES))
+    X_train_inf[0, 0] = np.inf
+    y = np.ones(10)
+    y[:5] = 0
+    y = _enforce_estimator_tags_y(estimator_orig, y)
+
+    for X_train in [X_train_nan, X_train_inf]:
+        estimator = clone(estimator_orig)
+        set_random_state(estimator, 1)
+        # fit must reject the non-finite input
+        with pytest.raises(ValueError, match=r"inf|NaN"):
+            estimator.fit(X_train, y)
+        # fit on finite (bool) data, then check predict/transform reject it too
+        estimator.fit(X_train_finite, y)
+        if hasattr(estimator, "predict"):
+            with pytest.raises(ValueError, match=r"inf|NaN"):
+                estimator.predict(X_train)
+        if hasattr(estimator, "transform"):
+            with pytest.raises(ValueError, match=r"inf|NaN"):
+                estimator.transform(X_train)
+
+
+def check_transformer_preserve_dtypes(name, transformer_orig):
+    # Check that dtype is preserved: bool in -> bool out. scihfs accepts only
+    # bool, so bool is the single supported dtype to preserve (sklearn iterates
+    # transformer_tags.preserves_dtype, which lists float dtypes the contract
+    # rejects).
+    transformer = clone(transformer_orig)
+    X, y = _binary_Xy(n_samples=30)
+    X = _enforce_estimator_tags_X(transformer_orig, X)
+
+    set_random_state(transformer)
+    X_trans1 = transformer.fit_transform(X, y)
+    X_trans2 = transformer.fit(X, y).transform(X)
+
+    for Xt, method in zip([X_trans1, X_trans2], ["fit_transform", "transform"]):
+        assert Xt.dtype == X.dtype, (
+            f"{name} (method={method}) does not preserve dtype. "
+            f"Original/Expected dtype={X.dtype}, got dtype={Xt.dtype}."
+        )
+
+
+_SECTION_B_CHECKS = [
+    check_estimator_sparse_array,
+    check_estimator_sparse_matrix,
+    check_estimator_sparse_tag,
+    check_readonly_memmap_input,
+    check_f_contiguous_array_estimator,
+    check_transformer_general,
+    check_estimators_nan_inf,
+    check_transformer_preserve_dtypes,
+]
+
+
+# ---------------------------------------------------------------------------
+# Section 2C:
+# Stubs ('pass') for those sklearn checks that fundamentally require
+# different data and cannot be faithfully recreated.
+# ---------------------------------------------------------------------------
+
+
+def check_dtype_object(name, estimator_orig):
+    # STUB: sklearn feeds object-dtype X and expects it treated as numeric. The
+    # bool-dtype contract rejects any non-bool dtype (object included), so the
+    # "treat object as numeric" intent cannot be exercised.
+    pass
+
+
+def check_estimators_dtypes(name, estimator_orig):
+    # STUB: sklearn fits on float32/float64/int X variants and expects all to
+    # work. All are non-bool and rejected by the contract.
+    pass
+
+
+def check_positive_only_tag_during_fit(name, estimator_orig):
+    # STUB: probes the positive_only tag by feeding negative values. A bool
+    # array has no negative values, and non-bool input is rejected for dtype
+    # (not for sign), so the tag cannot be exercised here.
+    pass
+
+
+_SECTION_C_CHECKS = [
+    check_dtype_object,
+    check_estimators_dtypes,
+    check_positive_only_tag_during_fit,
+]
+
+_SKLEARN_ADJACENT_CHECKS = _SECTION_A_CHECKS + _SECTION_B_CHECKS + _SECTION_C_CHECKS
+
+
+@pytest.mark.parametrize("check", _SKLEARN_ADJACENT_CHECKS, ids=lambda c: c.__name__)
+@pytest.mark.parametrize("estimator", ALL_ESTIMATORS)
+def test_binary_conformance(estimator, check):
+    est = estimator(_HIERARCHY)
+    check(type(est).__name__, est)

--- a/scihfs/tests/test_sklearn_conformance.py
+++ b/scihfs/tests/test_sklearn_conformance.py
@@ -229,7 +229,7 @@ def check_n_features_in_after_fitting(name, estimator_orig):
     tags = get_tags(estimator_orig)
     is_supported_X_types = tags.input_tags.two_d_array or tags.input_tags.categorical
     if not is_supported_X_types or tags.no_validation:
-        return
+        return  # pragma: no cover
 
     estimator = clone(estimator_orig)
     set_random_state(estimator)
@@ -256,7 +256,7 @@ def check_n_features_in_after_fitting(name, estimator_orig):
             continue
         callable_method = getattr(estimator, method)
         if method == "score":
-            callable_method = partial(callable_method, y=y)
+            callable_method = partial(callable_method, y=y)  # pragma: no cover
         with pytest.raises(ValueError, match=msg):
             callable_method(X_bad)
 
@@ -322,7 +322,7 @@ def check_fit_idempotent(name, estimator_orig):
             if hasattr(new_result, "dtype") and np.issubdtype(
                 new_result.dtype, np.floating
             ):
-                tol = 2 * np.finfo(new_result.dtype).eps
+                tol = 2 * np.finfo(new_result.dtype).eps  # pragma: no cover
             else:
                 tol = 2 * np.finfo(np.float64).eps
             assert_allclose_dense_sparse(
@@ -480,7 +480,7 @@ def check_fit_score_takes_y(name, estimator_orig):
             func(X, y)
             args = [p.name for p in signature(func).parameters.values()]
             if args[0] == "self":
-                args = args[1:]
+                args = args[1:]  # pragma: no cover
             assert args[1] in [
                 "y",
                 "Y",
@@ -536,7 +536,7 @@ def check_methods_subset_invariance(name, estimator_orig):
 def check_pipeline_consistency(name, estimator_orig):
     # make_pipeline(est) gives the same result as est on its own.
     if get_tags(estimator_orig).non_deterministic:
-        pytest.skip(name + " is non deterministic")
+        pytest.skip(name + " is non deterministic")  # pragma: no cover
 
     X, y = _binary_Xy(n_samples=30)
     X = _enforce_estimator_tags_X(estimator_orig, X)
@@ -631,7 +631,7 @@ def _check_estimator_sparse_container(name, estimator_orig, sparse_type):
 
     estimator.fit(X, y)
     if hasattr(estimator, "predict"):
-        assert estimator.predict(X).shape[0] == X.shape[0]
+        assert estimator.predict(X).shape[0] == X.shape[0]  # pragma: no cover
     if hasattr(estimator, "transform"):
         assert estimator.transform(X).shape[0] == X.shape[0]
 
@@ -657,13 +657,13 @@ def check_estimator_sparse_tag(name, estimator_orig):
     if tags.input_tags.sparse:
         try:
             estimator.fit(X, y)  # should pass
-        except Exception as e:
+        except Exception as e:  # pragma: no cover
             raise AssertionError(
                 f"Estimator {name} raised an exception. The tag "
                 f"self.input_tags.sparse={tags.input_tags.sparse} might not be "
                 "consistent with the estimator's ability to handle sparse data."
             ) from e
-    else:
+    else:  # pragma: no cover
         # No scihfs estimator declares sparse=False, but keep the branch
         # faithful to sklearn: it must then reject sparse with a clear message.
         try:
@@ -709,7 +709,7 @@ def check_f_contiguous_array_estimator(name, estimator_orig):
     if hasattr(estimator, "transform"):
         estimator.transform(X)
     if hasattr(estimator, "predict"):
-        estimator.predict(X)
+        estimator.predict(X)  # pragma: no cover
 
 
 def check_transformer_general(name, transformer_orig):
@@ -738,7 +738,7 @@ def _check_transformer_binary(name, transformer_orig, X, y):
         X_pred3 = transformer.fit_transform(X, y=y)
 
         if get_tags(transformer_orig).non_deterministic:
-            pytest.skip(name + " is non deterministic")
+            pytest.skip(name + " is non deterministic")  # pragma: no cover
 
         assert_allclose_dense_sparse(
             X_pred,
@@ -790,7 +790,7 @@ def check_estimators_nan_inf(name, estimator_orig):
             estimator.fit(X_train, y)
         # fit on finite (bool) data, then check predict/transform reject it too
         estimator.fit(X_train_finite, y)
-        if hasattr(estimator, "predict"):
+        if hasattr(estimator, "predict"):  # pragma: no cover
             with pytest.raises(ValueError, match=r"inf|NaN"):
                 estimator.predict(X_train)
         if hasattr(estimator, "transform"):


### PR DESCRIPTION
Adjacent to #102 / #103, the selectors have not yet been streamlined to **accept (and enforce) dtype=boolean input**, potentially handed over in a sparse data format.

That gap has been addressed with this PR:
- Added a check for dtype=bool in `base.fit()` and `lazyHierarchicalFeatureSelector.fit_selector()`
- Updated counts and distances accounting for the binary input features (and attempting to minimize memory footprints).
- Numerical branches in the _SHSEL_ and _Hill Climbing_ selector families have been disabled. Their code has been commented out, but numerical input would probably need a different approach in the future (consider metadata routing).
- The unfinished HieAODE selector has been taken out of this PR's equation.
- Fixtures have been updated to provide binary features.

Additionally, the entire **sklearn conformance test suite** has been rewritten:
- `test_sklearn_conformance.py` is a new dedicated file where all sklearn-related checks live. They are now organized in four sections:
  (1) The check_estimator tests from sklearn, applied to all scihfs estimators – with new exemptions for those tests that are expected to fail because of the enforcement of binary (boolean) features.
  (2A) Of the exempted tests in (1), those that would work with boolean input are recreated here exactly as in the sklearn blueprint.
  (2B) Of the exempted tests in (1), those that could be partially used are reimplemented with adaptations.
  (2C) All other exempted tests that cannot be recreated are implemented as 'pass' stubs.
- `test_common.py` is now dedicated to test selectors for scihfs API conformance (work in progress).
- `_estimators.py` is a new file that contains lists of estimators routed to specific tests, e.g., lazy vs. eager (work in progress).

Closes #118 