### PR TITLE
Widen package imports

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -56,3 +56,59 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  minimum-versions:
+    name: Run tests (for minimum supported versions)
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Set up Python 3.10 (scihfs current lower bound)
+        run: uv python install 3.10
+
+      - name: Install minimum supported versions for direct dependencies
+        run: uv sync --resolution lowest-direct --python 3.10
+
+      - name: Run tests
+        run: uv run --no-sync pytest scihfs
+
+  maximum-stable-versions:
+    name: Run tests (maximum stable versions)
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Set up Python 3.14 (scihfs current upper bound)
+        run: uv python install 3.14
+
+      - name: Install maximum stable versions for all dependencies
+        run: uv sync --upgrade --python 3.14
+
+      - name: Run tests
+        run: uv run --no-sync pytest scihfs

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 
 **IMPORTANT: This repository is under active development. Prior to the first release version, all contents are still preliminary and might change without notice.**
 
+[![SPEC 0 — Minimum Supported Dependencies](https://img.shields.io/badge/SPEC-0-green?labelColor=%23004811&color=%235CA038)](https://scientific-python.org/specs/spec-0000/)
+
 ====================================================
 scihfs - A library for hierarchical feature selection
 ====================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,12 +15,12 @@ license = { file = "LICENSE"}
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "info-gain>=1.0.1,<2",
-    "networkx>=3.2.1,<4",
-    "numpy>=2.0.0,<3",
-    "pandas>=2.2.3,<3",
-    "scikit-learn>=1.7.2,<2",
-    "scipy>=1.15.2,<2",
+    "info-gain>=1.0.0,<2", # Will be taken out once re-implemented
+    "networkx>=3.0.0,<4", # Clean major boundary, could technically be >=2.7.0
+    "numpy>=2.0.0,<3", # Required for py3.13+ compatibility
+    "pandas>=2.2.2,<4",  # First version compatible with numpy 2.0+
+    "scikit-learn>=1.6.0,<2", # First inclusion of validate_data
+    "scipy>=1.15.0,<2",  # <1.15 has no 1D sparse slicing yet
 ]
 
 [dependency-groups]

--- a/scihfs/tests/test_preprocessing.py
+++ b/scihfs/tests/test_preprocessing.py
@@ -1435,9 +1435,12 @@ def test_fit_no_columns_no_validation_error():
 def test_fit_rejects_duplicate_dataframe_column_names():
     """Duplicate DataFrame column names (feature_names_in_) are rejected.
 
-    validate_data captures DataFrame column labels verbatim into
-    feature_names_in_ without deduplication, so two columns sharing a name
-    auto-derive to the same hierarchy node. The fit-time guard catches it.
+    Either catched by scihfs at fit-time (raising "Duplicate
+    column->node mappings...") or already during validate_data with an
+    "Expected unique column names" ValueError (on scikit-learn >= 1.9 where
+    validate_data extracts feature names via narwhals).
+
+    Both are acceptable; as no duplicate columns make it through fit.
     """
     df = pd.DataFrame(
         np.array([[1, 0, 1], [0, 1, 1]], dtype=bool),
@@ -1445,5 +1448,5 @@ def test_fit_rejects_duplicate_dataframe_column_names():
     )
     graph = nx.DiGraph([("animal", "dog"), ("animal", "cat")])
     pre = HierarchicalPreprocessor(graph)
-    with pytest.raises(ValueError, match="Duplicate"):
+    with pytest.raises(ValueError, match="Duplicate|unique column names"):
         pre.fit(df)

--- a/scihfs/tests/test_sklearn_conformance.py
+++ b/scihfs/tests/test_sklearn_conformance.py
@@ -85,9 +85,7 @@ _BOOL_DTYPE_XFAIL_REASON = (
 # while these are recorded as expected failures. With on_fail='raise' (the
 # default), any NEW failure outside this set fails the test as a real regression.
 #
-# All ALL_ESTIMATORS share this identical set. It is sklearn-version-specific:
-# generated against sklearn 1.8.0. If sklearn is upgraded the set may drift --
-# re-enumerate (XPASS raises if a listed check actually starts passing).
+# All estimators in ALL_ESTIMATORS share this identical set.
 _EXPECTED_FAILED_CHECKS = {
     name: _BOOL_DTYPE_XFAIL_REASON
     for name in (

--- a/uv.lock
+++ b/uv.lock
@@ -2476,12 +2476,12 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "info-gain", specifier = ">=1.0.1,<2" },
-    { name = "networkx", specifier = ">=3.2.1,<4" },
+    { name = "info-gain", specifier = ">=1.0.0,<2" },
+    { name = "networkx", specifier = ">=3.0.0,<4" },
     { name = "numpy", specifier = ">=2.0.0,<3" },
-    { name = "pandas", specifier = ">=2.2.3,<3" },
-    { name = "scikit-learn", specifier = ">=1.7.2,<2" },
-    { name = "scipy", specifier = ">=1.15.2,<2" },
+    { name = "pandas", specifier = ">=2.2.2,<4" },
+    { name = "scikit-learn", specifier = ">=1.6.0,<2" },
+    { name = "scipy", specifier = ">=1.15.0,<2" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
_scihfs_ is now fully compatible with [SPEC-0](https://scientific-python.org/specs/spec-0000/) 🎉

- Added empirically validated floors to direct package dependencies (including comments).
- Updated tests to comply with latest sklearn release (v1.9.0)
- Added CI workflow to test (a) minimum direct dependencies (with currently minimum supported Python version 3.10), and (b) maximum resolvable (stable) dependencies (with currently maximum supported Python version 3.14).

Closes #120 