### PR TITLE
Fixed silent bug in hill climbing's indexing

### DIFF
--- a/scihfs/selectors/hill_climbing.py
+++ b/scihfs/selectors/hill_climbing.py
@@ -383,8 +383,6 @@ class BottomUpSelector(HillClimbingSelector):
         return self._calculate_similarity(sample_i, sample_j, feature_set)
 
     def _calculate_similarity(self, sample_i: int, sample_j: int, feature_set: list[int]):
-        if "ROOT" in feature_set:
-            feature_set = feature_set.remove("ROOT")
         row_i = self._score_matrix[sample_i, feature_set]
         row_j = self._score_matrix[sample_j, feature_set]
         return cosine_similarity(row_i.flatten(), row_j.flatten())

--- a/scihfs/tests/test_hill_climbing.py
+++ b/scihfs/tests/test_hill_climbing.py
@@ -119,6 +119,19 @@ def test_calculate_fitness_function_bu(
     assert np.array_equal(fitness, fitness_expected)
 
 
+def test_calculate_similarity_rejects_root(data1):
+    # feature_set reaching _calculate_similarity is contractually ROOT-free
+    # (see select_and_return_features). If "ROOT" ever slipped in regardless,
+    # fancy-indexing a numpy array with a mixed str/int list must fail loudly
+    # rather than silently falling back to `arr[i, None]` semantics.
+    X, y, hierarchy, columns = data1
+    selector = BottomUpSelector(hierarchy, k=3)
+    selector.fit(X, y, columns)
+
+    with pytest.raises(IndexError):
+        selector._calculate_similarity(0, 1, ["ROOT", columns[0]])
+
+
 def test_calculate_fitness_function_td(
     data1, result_comparison_matrix_td1, result_fitness_funtion_td1
 ):


### PR DESCRIPTION
Removed ambiguous indexing in similarity metrics calculation of the Bottom-Up Hill-Climbing method. Added a corresponding test.