### PR TITLE
Redesign of lazy HFS methods

### DIFF
--- a/examples/lazy_learning_example.py
+++ b/examples/lazy_learning_example.py
@@ -1,178 +1,107 @@
 # -*- coding: utf-8 -*-
-# %%
 """
+CAUTION: Work in progress! The API (and this example) is not yet stable and may change without deprecation. Please reach out if you want to use or contribute to this library.
+
 Lazy learning
 =====================
 
-These methods can help you with the correct usage of the library's lazy learning methods.
-The dataset as well as the hierarchy are structures not following a specific pattern, but just showing how to use the interfaces properly.
+These examples show how to use the library's *lazy* hierarchical feature selection
+methods -- which are embedded methods that (a) behave like a classifier, and (b)
+are not trained in the usual sense, but apply their selection logic per test instance.
+
+Following the scikit-learn *classifiers* scheme: ``fit`` does the
+one-off work (such as determining relevance scores for all features in the dataset),
+while ``predict`` selects a feature subset *per test instance* AND at the same time
+classifies it.
+[``select`` exposes those per-instance selection masks on their own.]
+Any selector below can be swapped for another and used in exactly the same way.
 """
 
 import networkx as nx
 import numpy as np
 
-from scihfs.preprocessing import HierarchicalPreprocessor
+from scihfs.metrics import mean_selected_fraction, sensitivity_specificity_product
 from scihfs.selectors import HIP, HNB, MR, RNB, TAN, HNBs
 
+# 4 training + 2 test samples, 4 bool features.
+X_train = np.array([[1, 1, 0, 1], [1, 0, 0, 0], [1, 1, 1, 0], [1, 1, 1, 1]], dtype=bool)
+y_train = np.array([0, 0, 1, 1])
+X_test = np.array([[1, 1, 0, 0], [1, 1, 1, 0]], dtype=bool)
+y_test = np.array([0, 1])
 
-# Define data
-def data():
-    train_x_data = np.array(
-        [[1, 1, 0, 1], [1, 0, 0, 0], [1, 1, 1, 0], [1, 1, 1, 1]], dtype=bool
-    )
-    train_y_data = np.array([0, 0, 1, 1])
-    test_x_data = np.array([[1, 1, 0, 0], [1, 1, 1, 0]], dtype=bool)
-    test_y_data = np.array([0, 1])
-    hierarchy = nx.to_numpy_array(nx.DiGraph([(0, 1), (0, 2), (1, 2), (1, 3)]))
-    return (train_x_data, train_y_data, test_x_data, test_y_data, hierarchy)
+# Hierarchy over the 4 columns (node i corresponds to column i), as an
+# adjacency matrix -- the positional column<->node default applies.
+hierarchy = nx.to_numpy_array(nx.DiGraph([(0, 1), (0, 2), (1, 2), (1, 3)]))
 
-
-# Preprocess to fit data and hierarchy to each other
-def preprocess():
-    train_x_data, train_y_data, test_x_data, test_y_data, hierarchy = data()
-    preprocessor = HierarchicalPreprocessor(hierarchy=hierarchy)
-    preprocessor.fit(train_x_data)
-    train = preprocessor.transform(train_x_data)
-    test = preprocessor.transform(test_x_data)
-    hierarchy = preprocessor.to_adjacency_matrix()
-    return (train, test, train_y_data, test_y_data, hierarchy)
-
-
-train, test, train_y_data, test_y_data, hierarchy = preprocess()
-# %%
-"""
-=========================================================================
-HieAODE -
-=========================================================================
-"""
-
-# TODO: Update this section once merged with main (currently outdated).
-# The following is the original code snippet for HieAODE, now commented out.
-
-# print("\nHieAODE:")
-# # Initialize and fit HNB model with threshold k = 3 features to select
-# model = HieAODE(hierarchy=hierarchy)
-# model.fit_selector(X_train=train, y_train=train_y_data, X_test=test)
-# # %%
-# # Select features and predict
-# predictions = model.select_and_predict(predict=True, saveFeatures=True)
-# print(predictions)
-# # %%
-# # Calculate score
-# score = model.get_score(test_y_data, predictions)
-# print(score)
-
-"""
-=========================================================================
-HNB - Hierarchy Based Redundant Attribute Removal Naive Bayes Classifier
-=========================================================================
-"""
-
-print("\nHNB:")
-# Initialize and fit HNB model with threshold k = 3 features to select
 model = HNB(hierarchy=hierarchy, k=3)
-model.fit_selector(X_train=train, y_train=train_y_data, X_test=test)
+model.fit(X_train, y_train)
 
-# Select features and predict
-predictions = model.select_and_predict(predict=True, saveFeatures=True)
-print(predictions)
+# ``predict`` -> per-instance labels; ``select`` -> per-instance selection masks.
+print("predictions:", model.predict(X_test))
+print("selection masks:\n", model.select(X_test))
 
-# Calculate score
-score = model.get_score(test_y_data, predictions)
-print(score)
+# Both from a single sweep -- ``masks`` is identical to ``select(X_test)``.
+predictions, masks = model.predict(X_test, return_masks=True)
+
+# Calibrated class probabilities and the built-in accuracy score.
+print("probabilities:\n", model.predict_proba(X_test))
+print("accuracy:", model.score(X_test, y_test))
+
+# The bespoke metrics that are used in many of the lazy HFS papers.
+print("sensitivity*specificity:", sensitivity_specificity_product(y_test, predictions))
+print("mean selected fraction:", mean_selected_fraction(masks))
+
+# Lazy HFS methods have the same API and can be used interchangeably.
+family = [
+    ("HIP", HIP(hierarchy=hierarchy)),
+    ("HNB", HNB(hierarchy=hierarchy, k=3)),
+    ("HNBs", HNBs(hierarchy=hierarchy)),
+    ("RNB", RNB(hierarchy=hierarchy, k=3)),
+    ("MR", MR(hierarchy=hierarchy)),
+    ("TAN", TAN(hierarchy=hierarchy)),
+]
+for name, selector in family:
+    selector.fit(X_train, y_train)
+    print(f"{name}: {selector.predict(X_test)}")
 
 # %%
-"""
-=========================================================================
-HNB-s
-=========================================================================
-"""
+# DataFrame input: the column->node mapping is auto-derived
+# ---------------------------------------------------------
+# All scihfs methods also accept a pandas ``DataFrame`` as input, in addition
+# to plain arrays and sparse matrices.
+# If combined with a named ``networkx.DiGraph`` hierarchy, the column->node mapping is auto-derived from the feature names, so that no explicit ``columns=`` argument is needed.
 
-print("HNB-s:")
-# Initialize and fit HNBs model
-model = HNBs(hierarchy=hierarchy)
-model.fit_selector(X_train=train, y_train=train_y_data, X_test=test)
+import pandas as pd
 
-# Select features and predict
-predictions = model.select_and_predict(predict=True, saveFeatures=True)
-print(predictions)
+# Bool DataFrame whose columns are named after hierarchy nodes, in shuffled
+# order (so a positional mapping would be wrong).
+df_train = pd.DataFrame(
+    {
+        "cat": [1, 0, 1, 1],
+        "animal": [1, 1, 1, 1],
+        "eagle": [0, 0, 1, 0],
+        "mammal": [1, 0, 1, 1],
+    }
+).astype(bool)
+df_test = pd.DataFrame(
+    {
+        "cat": [0, 1],
+        "animal": [1, 1],
+        "eagle": [0, 1],
+        "mammal": [1, 1],
+    }
+).astype(bool)
 
-# Calculate score
-score = model.get_score(test_y_data, predictions)
-print(score)
+# Named hierarchy -- nodes carry meaningful labels instead of column indices.
+named_hierarchy = nx.DiGraph(
+    [("animal", "mammal"), ("mammal", "cat"), ("animal", "eagle")]
+)
 
+model = HNB(hierarchy=named_hierarchy, k=3)
+model.fit(df_train, y_train)
 
-"""
-==================================
-RNB - Relevance-based Naive Bayes
-==================================
-"""
-
-print("\nRNB:")
-# Initialize and fit RNB model with threshold k = 3 features to select
-model = RNB(hierarchy=hierarchy)
-model.fit_selector(X_train=train, y_train=train_y_data, X_test=test)
-
-# Select features and predict
-predictions = model.select_and_predict(predict=True, saveFeatures=True)
-print(predictions)
-
-# Calculate score
-score = model.get_score(test_y_data, predictions)
-print(score)
-
-
-"""
-=======================================
-MR -  Most Relevant Feature Selection
-=======================================
-"""
-print("\nMR:")
-# Initialize and fit MR model
-model = MR(hierarchy=hierarchy)
-model.fit_selector(X_train=train, y_train=train_y_data, X_test=test)
-
-# Select features and predict
-predictions = model.select_and_predict(predict=True, saveFeatures=True)
-print(predictions)
-
-# Calculate score
-score = model.get_score(test_y_data, predictions)
-print(score)
-
-
-"""
-==========================================
-HIP - Hierarchical Information Preserving
-==========================================
-"""
-print("\nHIP:")
-# Initialize and fit HIP model
-model = HIP(hierarchy=hierarchy)
-model.fit_selector(X_train=train, y_train=train_y_data, X_test=test)
-
-# Select features and predict
-predictions = model.select_and_predict(predict=True, saveFeatures=True)
-print(predictions)
-
-# Calculate score
-score = model.get_score(test_y_data, predictions)
-print(score)
-
-"""
-====================================================================
-TAN - Hierarchical Redundancy Eliminated Tree Augmented Naive Bayes
-====================================================================
-"""
-print("\nTAN:")
-# Initialize and fit Tan model
-model = TAN(hierarchy=hierarchy)
-model.fit_selector(X_train=train, y_train=train_y_data, X_test=test)
-
-# Select features and predict
-predictions = model.select_and_predict(predict=True, saveFeatures=True)
-print(predictions)
-
-# Calculate score
-score = model.get_score(test_y_data, predictions)
-print(score)
+# The mapping was derived from the feature names (columns cat, animal, eagle,
+# mammal -> nodes 2, 0, 3, 1).
+print("auto-derived column->node mapping:", model.get_columns())
+print("predictions:", model.predict(df_test))
+print("selection masks (plain ndarray):\n", model.select(df_test))

--- a/scihfs/helpers.py
+++ b/scihfs/helpers.py
@@ -10,6 +10,7 @@ import networkx as nx
 import numpy as np
 import scipy.sparse as sp
 from networkx.algorithms.simple_paths import all_simple_paths
+from sklearn.utils.multiclass import type_of_target
 
 
 def get_relevance(xdata, ydata, node):
@@ -65,6 +66,25 @@ def check_bool_dtype(X):
             f"If your data is binary, convert with X.astype(bool). "
             f"Non-binary (numeric) inputs are not yet supported - "
             f"see the sum-propagation roadmap for HFE workflows."
+        )
+
+
+def check_binary_target(y):
+    """Raise ValueError unless ``y`` has a binary target encoding drawing
+    from ``{0, 1}` (can also be encoded as boolean ``False`` and ``True``).
+    """
+    y_type = type_of_target(y, input_name="y")
+    if y_type != "binary":
+        raise ValueError(
+            f"Only binary classification is supported. scihfs estimators "
+            f"require a binary target; got y_type={y_type!r}."
+        )
+    labels = set(np.unique(y).tolist())
+    if not labels <= {0, 1}:
+        raise ValueError(
+            f"scihfs estimators require the binary target to be labelled 0 and "
+            f"1 (boolean False and True, respectively); got"
+            f"classes={sorted(labels)!r}. Relabel the encodings before fitting."
         )
 
 

--- a/scihfs/helpers.py
+++ b/scihfs/helpers.py
@@ -92,40 +92,6 @@ def _check_unique_column_mappings(columns):
         )
 
 
-def check_data(dag, x_data, y_data):
-    """Checks whether the given dataset satisfies the 0-1-propagation on the DAG.
-
-    The 0-1-propagation property states that if there is a directed edge (u, v)
-    in the DAG, then whenever node u has a value of 1 in the dataset, node v
-    must have a value of 1 for the same instance.
-
-    Parameters
-    ----------
-    dag : networkx.DiGraph
-        The Directed Acyclic Graph representing the hierarchy structure.
-    x_data : numpy.ndarray
-            An array containing the input features of the dataset.
-    y_data : numpy.ndarray
-            An array containing the corresponding output labels of the dataset.
-
-    Raises
-    ----------
-    ValueError: If the dataset violates the 0-1-propagation property
-    on any of the edges in the DAG.
-
-    """
-    data = np.column_stack((x_data, y_data))
-    edges = list(nx.edge_dfs(dag, source=0, orientation="original"))
-    for edge in edges:
-        for idx in range(len(data)):
-            if data[idx, edge[0]] == 0 and data[idx, edge[1]] == 1:
-                raise ValueError(
-                    f"Test instance {idx} violates 0-1-propagation \
-                    on edge ({edge[0]}, {edge[1]})"
-                    f"{data[idx]}"
-                )
-
-
 def get_leaves(graph: nx.DiGraph):
     """Get the leaf nodes from the given directed acyclic graph (DAG).
 

--- a/scihfs/metrics.py
+++ b/scihfs/metrics.py
@@ -5,7 +5,7 @@ Different metric functions.
 import numpy as np
 from numpy.linalg import norm
 from scipy import sparse
-from sklearn.metrics import mutual_info_score
+from sklearn.metrics import mutual_info_score, recall_score
 
 
 def _information_gain(feature: np.ndarray, target: np.ndarray) -> float:
@@ -244,6 +244,45 @@ def gain_ratio(data, labels):
         gr = _gain_ratio(column, labels)
         gr_values.append(gr)
     return gr_values
+
+
+def sensitivity_specificity_product(y_true, y_pred):
+    """Product of sensitivity and specificity for a binary {0, 1} target.
+
+    Common metric in the lazy hierarchical classifiers literature; ``score`` on
+    the (lazy) classifiers only gives plain accuracy.
+
+    Parameters
+    ----------
+    y_true : array-like of shape (n_samples,)
+        The ground-truth labels (0/1).
+    y_pred : array-like of shape (n_samples,)
+        The predicted labels (0/1).
+
+    Returns
+    ----------
+    float : sensitivity * specificity.
+    """
+    sensitivity = recall_score(y_true, y_pred, pos_label=1, zero_division=0)
+    specificity = recall_score(y_true, y_pred, pos_label=0, zero_division=0)
+    return float(sensitivity) * float(specificity)
+
+
+def mean_selected_fraction(masks):
+    """Mean fraction of features selected per instance ("compression").
+
+    Parameters
+    ----------
+    masks : array-like of shape (n_samples, n_features), dtype bool
+        The per-instance selection masks, as returned by a lazy selector's
+        ``select`` method.
+
+    Returns
+    ----------
+    float : The mean fraction of selected features per instance, in [0, 1].
+    """
+    masks = np.asarray(masks, dtype=bool)
+    return float(masks.mean())
 
 
 def pearson_correlation(i: np.ndarray, j: np.ndarray):

--- a/scihfs/selectors/base.py
+++ b/scihfs/selectors/base.py
@@ -268,6 +268,60 @@ class HierarchyMixin:
         # Get the corresponding column index for a node in the hierarchy.
         return self._columns.index(node)
 
+    def _reject_column_node_mismatch(self):
+        """Raise if the hierarchy nodes and data columns are not in bijection.
+
+        Necessary for all HFS methods (eager and lazy), but not for the preprocessor
+        (which aligns them automatically).
+
+        Raises
+        ------
+        ValueError
+            If any hierarchy node has no data column, or any data column has no
+            hierarchy node.
+        """
+        nodes = set(self._hierarchy_graph.nodes()) - {"ROOT"}
+        mapped = set(self._columns)
+        nodes_without_column = nodes - mapped
+        columns_without_node = mapped - nodes
+        if not nodes_without_column and not columns_without_node:
+            return
+        node_names = [
+            self._hierarchy_graph.nodes[node].get(ORIGINAL_NODE_IDENTIFIER, node)
+            for node in sorted(nodes_without_column)
+        ]
+        orphan_columns = sorted(
+            column
+            for column, node in enumerate(self._columns)
+            if node in columns_without_node
+        )
+        raise ValueError(
+            "Hierarchy and data columns are not aligned: "
+            f"hierarchy node(s) with no data column: {node_names}; "
+            f"data column(s) with no hierarchy node: {orphan_columns}. Every "
+            "node must map to exactly one column and vice versa. Use the "
+            "HierarchicalPreprocessor to align them, or pass a matching "
+            "``columns`` mapping."
+        )
+
+    def _relabel_hierarchy_to_columns(self):
+        """Relabel ``_hierarchy_graph`` from node positions to column indices.
+
+        The output from this method is a copy of the hierarchy graph with the
+        nodes relabelled to the corresponding column indices in the dataset.
+
+        Running this method is a prerequisite for the lazy HFS methods, which
+        index ``x_row[node]`` directly (= without ``_column_index`` lookup).
+        (The eager HFS methods translate node -> column on demand via
+        ``_column_index``.)
+        """
+        self._reject_column_node_mismatch()
+        self._hierarchy_graph.remove_node("ROOT")
+        node_to_column = {
+            position: column for column, position in enumerate(self._columns)
+        }
+        self._hierarchy_graph = nx.relabel_nodes(self._hierarchy_graph, node_to_column)
+
 
 class HierarchicalEstimator(TransformerMixin, HierarchyMixin, BaseEstimator):
     """Base class for estimators using hierarchical data.

--- a/scihfs/selectors/base.py
+++ b/scihfs/selectors/base.py
@@ -11,6 +11,7 @@ from sklearn.utils.validation import check_is_fitted, validate_data
 from scihfs.helpers import (
     _check_unique_column_mappings,
     add_virtual_root_node,
+    check_binary_target,
     check_bool_dtype,
 )
 
@@ -336,6 +337,7 @@ class HierarchicalEstimator(TransformerMixin, HierarchyMixin, BaseEstimator):
             X = validate_data(self, X, y, accept_sparse=True)
         else:
             X, y = validate_data(self, X, y, accept_sparse=True)
+            check_binary_target(y)
         check_bool_dtype(X)
         self._fit_hierarchy(columns)
         self._fit(X, y)

--- a/scihfs/selectors/base.py
+++ b/scihfs/selectors/base.py
@@ -283,22 +283,23 @@ class HierarchyMixin:
         nodes = set(self._hierarchy_graph.nodes()) - {"ROOT"}
         mapped = set(self._columns)
         nodes_without_column = nodes - mapped
-        columns_without_node = mapped - nodes
+        # A data column is unmapped if it has no entry in _columns or its entry
+        # points at a node absent from the hierarchy graph.
+        columns_without_node = [
+            column
+            for column in range(self.n_features_in_)
+            if column >= len(self._columns) or self._columns[column] not in nodes
+        ]
         if not nodes_without_column and not columns_without_node:
             return
         node_names = [
             self._hierarchy_graph.nodes[node].get(ORIGINAL_NODE_IDENTIFIER, node)
             for node in sorted(nodes_without_column)
         ]
-        orphan_columns = sorted(
-            column
-            for column, node in enumerate(self._columns)
-            if node in columns_without_node
-        )
         raise ValueError(
             "Hierarchy and data columns are not aligned: "
             f"hierarchy node(s) with no data column: {node_names}; "
-            f"data column(s) with no hierarchy node: {orphan_columns}. Every "
+            f"data column(s) with no hierarchy node: {columns_without_node}. Every "
             "node must map to exactly one column and vice versa. Use the "
             "HierarchicalPreprocessor to align them, or pass a matching "
             "``columns`` mapping."

--- a/scihfs/selectors/base.py
+++ b/scihfs/selectors/base.py
@@ -19,22 +19,42 @@ from scihfs.helpers import (
 ORIGINAL_NODE_IDENTIFIER = "_scihfs_original_node_identifier"
 
 
-class HierarchicalEstimator(TransformerMixin, BaseEstimator):
-    """Base class for estimators using hierarchical data.
+class HierarchyMixin:
+    """Hierarchy-core mixin for handling the ``hierarchy`` parameter.
 
-    The HierarchicalEstimator implements scikit-learn's BaseEstimator and
-    TransformerMixin interfaces. It can be used as a base class for feature
-    selection classes or data preprocessors that use hierarchical data.
+    Holds everything needed to turn the ``hierarchy`` constructor argument into
+    a validated ``_hierarchy_graph`` plus the column->node mapping, *without*
+    committing to any scikit-learn fit/transform/predict contract. It carries
+    no ``TransformerMixin``/``ClassifierMixin`` surface and defines no ``fit``.
 
-    ..note:: This estimator currently supports only bool-dtype input.
-    Non-binary (numeric) inputs raise ``ValueError``. Sum-propagation
-    for numeric features could be a future enhancement.
+    Estimators combine it with ``BaseEstimator`` and the mixin matching their
+    role:
+
+    - ``HierarchicalEstimator(TransformerMixin, HierarchyMixin, BaseEstimator)``
+      -- the transformer fit-template used by the preprocessor and the eager
+      selectors.
+    - The lazy selectors pair it with a classifier surface directly.
+
+    Two things share the word "validation", and only one lives here.
+    *Hierarchy* validation is this mixin's job: format dispatch
+    (``_set_hierarchy``), acyclicity (``_check_dag``), and the unique/orphan
+    column->node mapping (``_auto_derive_columns`` /
+    ``_handle_orphan_features``). X *data* validation (dtype, finiteness,
+    shape) is deliberately not: it is the host estimator's boundary
+    responsibility, performed once per public method via ``validate_data``.
+    That split is intentional -- data validation is role-specific (whether
+    ``y`` is required and whether sparse is accepted come from the host's
+    tags) and fires again at ``transform`` / ``predict`` time, neither of
+    which this mixin sees. These methods here therefore consume only the
+    *products* of that validation: ``self.n_features_in_`` (and, for DataFrame
+    input, ``self.feature_names_in_``), set by the host before
+    ``_fit_hierarchy`` runs.
     """
 
     def __init__(
         self, hierarchy: np.ndarray | sp.sparray | sp.spmatrix | nx.DiGraph | None = None
     ):
-        """Initializes a HierarchicalEstimator.
+        """Initializes a HierarchyMixin.
 
         Parameters
         ----------
@@ -47,74 +67,6 @@ class HierarchicalEstimator(TransformerMixin, BaseEstimator):
                     Note: ``None`` is accepted for scikit-learn ``clone()``
                     compatibility but raises ``TypeError`` in ``fit``."""
         self.hierarchy = hierarchy
-
-    def __sklearn_tags__(self):
-        tags = super().__sklearn_tags__()
-        tags.input_tags.sparse = True
-        return tags
-
-    def fit(self, X, y=None, columns=None):
-        """Template fitting function shared by all estimators of this family.
-
-        X (and y, when given) are validated exactly once on this path, so
-        ``feature_names_in_`` captured from a DataFrame input survives
-        fitting. The hierarchy is then transformed to a nx.DiGraph with a
-        virtual root node named "ROOT" that connects all parts of the graph
-        to one component, and the subclass's ``_fit`` hook is run.
-
-        Parameters
-        ----------
-        X : {array-like, sparse matrix}, shape (n_samples, n_features)
-            The training input samples.
-        y : array-like, shape (n_samples,) or None
-            The target values. Required by the supervised subclasses (the
-            eager selectors); ignored by the purely structural transformers.
-        columns: list or None
-            The mapping from the hierarchy graph's nodes to the columns in X.
-            A list of ints. If this parameter is None the columns in X and
-            the corresponding nodes in the hierarchy are expected to be in
-            the same order -- unless X was passed as a DataFrame and the
-            hierarchy is a named ``nx.DiGraph``; then the mapping is
-            auto-derived from the feature names (see
-            ``_auto_derive_columns``).
-
-        Raises
-        ------
-        TypeError
-            If the passed hierarchy is None.
-        ValueError
-            If X is not bool-dtype (numerical inputs may be supported in the
-            future); if y is None on a supervised subclass (selectors); or if the
-            column->node mapping cannot be auto-derived for a DataFrame X
-            (adjacency-matrix hierarchy without node names, or feature names
-            with no matching node -- see ``_handle_orphan_features``).
-
-        Returns
-        -------
-        self : object
-            Returns self.
-        """
-        if self.hierarchy is None:
-            raise TypeError("Hierarchy is None but is required.")
-        if y is None:
-            # validate_data raises here for supervised subclasses
-            # (target_tags.required) and validates X alone otherwise.
-            X = validate_data(self, X, y, accept_sparse=True)
-        else:
-            X, y = validate_data(self, X, y, accept_sparse=True)
-        check_bool_dtype(X)
-        self._fit_hierarchy(columns)
-        self._fit(X, y)
-
-        self.is_fitted_ = True
-        return self
-
-    def _fit(self, X, y):
-        """Hook for the subclass's fitting logic.
-
-        Called by ``fit`` with the validated X and y after the hierarchy
-        setup. The base implementation does nothing.
-        """
 
     def _fit_hierarchy(self, columns):
         """Set ``_columns`` and build ``_hierarchy_graph`` from a validated X.
@@ -216,26 +168,6 @@ class HierarchicalEstimator(TransformerMixin, BaseEstimator):
             "explicitly."
         )
 
-    def transform(self, X):
-        """Reduce X to the selected features.
-
-        Extend this methods to actually transform the dataset.
-
-        Parameters
-        ----------
-        X : array of shape (n_samples, n_features)
-            The input samples.
-
-        Returns
-        -------
-        X : array of shape (n_samples, n_selected_features)
-            The input samples with only the selected features.
-        """
-        check_is_fitted(self)
-        X = validate_data(self, X, accept_sparse="csr", reset=False)
-
-        return X
-
     def get_columns(self):
         """Get mapping from the dataset's columns to the hierarchy's nodes.
 
@@ -334,3 +266,106 @@ class HierarchicalEstimator(TransformerMixin, BaseEstimator):
     def _column_index(self, node):
         # Get the corresponding column index for a node in the hierarchy.
         return self._columns.index(node)
+
+
+class HierarchicalEstimator(TransformerMixin, HierarchyMixin, BaseEstimator):
+    """Base class for estimators using hierarchical data.
+
+    The HierarchicalEstimator combines scikit-learn's ``TransformerMixin`` and
+    ``BaseEstimator`` with :class:`HierarchyMixin` from scihfs (the hierarchy core).
+    It is the transformer fit-template for the data preprocessor and the eager
+    feature selectors, with single input-validation pass, the hierarchy setup,
+    and a ``_fit`` hook.
+
+    ..note:: This estimator currently supports only bool-dtype input.
+    Non-binary (numeric) inputs raise ``ValueError``. Sum-propagation
+    for numeric features could be a future enhancement.
+    """
+
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.input_tags.sparse = True
+        return tags
+
+    def fit(self, X, y=None, columns=None):
+        """Template fitting function shared by all estimators of this family.
+
+        X (and y, when given) are validated exactly once on this path, so
+        ``feature_names_in_`` captured from a DataFrame input survives
+        fitting. The hierarchy is then transformed to a nx.DiGraph with a
+        virtual root node named "ROOT" that connects all parts of the graph
+        to one component, and the subclass's ``_fit`` hook is run.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix}, shape (n_samples, n_features)
+            The training input samples.
+        y : array-like, shape (n_samples,) or None
+            The target values. Required by the supervised subclasses (the
+            eager selectors); ignored by the purely structural transformers.
+        columns: list or None
+            The mapping from the hierarchy graph's nodes to the columns in X.
+            A list of ints. If this parameter is None the columns in X and
+            the corresponding nodes in the hierarchy are expected to be in
+            the same order -- unless X was passed as a DataFrame and the
+            hierarchy is a named ``nx.DiGraph``; then the mapping is
+            auto-derived from the feature names (see
+            ``_auto_derive_columns``).
+
+        Raises
+        ------
+        TypeError
+            If the passed hierarchy is None.
+        ValueError
+            If X is not bool-dtype (numerical inputs may be supported in the
+            future); if y is None on a supervised subclass (selectors); or if the
+            column->node mapping cannot be auto-derived for a DataFrame X
+            (adjacency-matrix hierarchy without node names, or feature names
+            with no matching node -- see ``_handle_orphan_features``).
+
+        Returns
+        -------
+        self : object
+            Returns self.
+        """
+        if self.hierarchy is None:
+            raise TypeError("Hierarchy is None but is required.")
+        if y is None:
+            # validate_data raises here for supervised subclasses
+            # (target_tags.required) and validates X alone otherwise.
+            X = validate_data(self, X, y, accept_sparse=True)
+        else:
+            X, y = validate_data(self, X, y, accept_sparse=True)
+        check_bool_dtype(X)
+        self._fit_hierarchy(columns)
+        self._fit(X, y)
+
+        self.is_fitted_ = True
+        return self
+
+    def _fit(self, X, y):
+        """Hook for the subclass's fitting logic.
+
+        Called by ``fit`` with the validated X and y after the hierarchy
+        setup. The base implementation does nothing.
+        """
+
+    def transform(self, X):
+        """Reduce X to the selected features.
+
+        Extend this methods to actually transform the dataset.
+
+        Parameters
+        ----------
+        X : array of shape (n_samples, n_features)
+            The input samples.
+
+        Returns
+        -------
+        X : array of shape (n_samples, n_selected_features)
+            The input samples with only the selected features.
+        """
+        check_is_fitted(self)
+        X = validate_data(self, X, accept_sparse="csr", reset=False)
+
+        return X

--- a/scihfs/selectors/eagerHierarchicalFeatureSelector.py
+++ b/scihfs/selectors/eagerHierarchicalFeatureSelector.py
@@ -2,7 +2,6 @@
 Base class for estimators for eager hierarchical feature selection.
 """
 
-import warnings
 from abc import abstractmethod
 
 import numpy as np
@@ -42,10 +41,10 @@ class EagerHierarchicalFeatureSelector(SelectorMixin, HierarchicalEstimator):
     def _fit(self, X, y):
         """Runs the eager feature selection on the validated X and y.
 
-        Checks the hierarchy against X, resets ``representatives_`` and
+        Rejects a hierarchy/column mismatch, resets ``representatives_`` and
         delegates to the subclasses' ``_select``.
         """
-        self._check_hierarchy_X()
+        self._reject_column_node_mismatch()
 
         # self.representatives_ includes all node names for selected nodes.
         # self._columns maps them to the respective column in X.
@@ -73,26 +72,3 @@ class EagerHierarchicalFeatureSelector(SelectorMixin, HierarchicalEstimator):
                 for index in range(self.n_features_in_)
             ]
         )
-
-    def _check_hierarchy_X(self):
-        not_in_hierarchy = [
-            feature_index
-            for feature_index in range(self.n_features_in_)
-            if feature_index not in self._columns
-        ]
-        if not_in_hierarchy:
-            warning_missing_nodes = """All columns in X need to be mapped
-             to a node in the hierarchy. If columns=None the corresponding
-             node's name is the same as the column's index in the dataset.
-             Otherwise, it is indicated by the value in self._columns at
-             the columns' index."""
-            warnings.warn(warning_missing_nodes)
-
-        nodes = list(self._hierarchy_graph.nodes())
-        nodes.remove("ROOT")
-        not_in_dataset = [node for node in nodes if node not in self._columns]
-        if not_in_dataset:
-            warning_missing_columns = """The hierarchy should not include any
-             nodes that are not mapped to a column in the dataset by the
-             columns parameter"""
-            warnings.warn(warning_missing_columns)

--- a/scihfs/selectors/hie_aode.py
+++ b/scihfs/selectors/hie_aode.py
@@ -1,43 +1,20 @@
 import networkx as nx
 import numpy as np
-import scipy.sparse as sp
-from sklearn.naive_bayes import BernoulliNB
+from sklearn.utils.validation import check_is_fitted, validate_data
+
+from scihfs.helpers import check_bool_dtype
 
 from .lazyHierarchicalFeatureSelector import LazyHierarchicalFeatureSelector
 
 
 class HieAODE(LazyHierarchicalFeatureSelector):
+    """Lazy HieAODE classifier (Wan & Freitas).
+
+    Placeholder implementation.
     """
-    Select non-redundant features following the algorithm proposed by Wan and Freitas.
-    """
 
-    def __init__(
-        self, hierarchy: np.ndarray | sp.sparray | sp.spmatrix | nx.DiGraph | None = None
-    ):
-        """Initializes a HieAODE-Selector.
-
-        Parameters
-        ----------
-        hierarchy : np.ndarray, scipy.sparse array/matrix or nx.DiGraph
-            The hierarchy graph. See ``HierarchicalEstimator.__init__``
-            for the accepted formats.
-        """
-        super().__init__(hierarchy)
-        self.cpts = dict()
-
-    def fit_selector(self, X_train, y_train, X_test, columns=None):
-        """
-        P (y, x_i )
-        class_prior
-
-        self.n_ancestors = self._n_descendants = self.n_features
-        P (x_k|y)
-        ancestors_class_cpt = (self.n_ancestors, self.n_classes, self.n_features_in, n_values)
-
-        P (x_j|y, x_i)
-        feature_descendants_class_cpt = (self.n_features_in, self._n_descendants, self.n_classes_, n_values)
-        """
-        super(HieAODE, self).fit_selector(X_train, y_train, X_test, columns)
+    def _fit(self, X, y):
+        """Allocate the conditional-probability tables from the fitted shapes."""
         self.cpts = dict(
             prior=np.full((self.n_features_in_, self.n_classes_, 2), -1),
             # (x_j (descendent), x_i (current feature), class, value)  # P(y, x_i )
@@ -47,31 +24,24 @@ class HieAODE(LazyHierarchicalFeatureSelector):
             ancestors=np.full((self.n_features_in_, self.n_classes_, 2), -1),  # P(x_k|y)
         )
 
-    def select_and_predict(
-        self, predict=True, saveFeatures=False, estimator=BernoulliNB()
-    ):
-        """
-        Select features lazy for each test instance and optionally predict target value of test instances
-        using the HieAODE algorithm by Wan and Freitas
+    def _select_features_per_instance(self, x_row):
+        # HieAODE overrides predict wholesale and does not use per-instance
+        # subset selection; this placeholder keeps the abstract base satisfied.
+        return {node: 1 for node in self._hierarchy_graph}
 
-        Parameters
-        ----------
-        predict : bool
-            true if predictions shall be obtained.
-        saveFeatures : bool
-            true if features selected for each test instance shall be saved.
-        estimator : sklearn-compatible estimator
-            Estimator to use for predictions.
+    def predict_proba(self, X):
+        """Placeholder implementation."""
+        raise AttributeError("HieAODE does not support predict_proba.")
 
-
-        Returns
-        -------
-        predictions for test input samples, if predict = false, returns empty array.
-        """
-        n_samples = self._xtest.shape[0]
+    def predict(self, X):
+        """Predict the target value for each instance in X using HieAODE."""
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False)
+        check_bool_dtype(X)
+        n_samples = X.shape[0]
         sample_sum = np.zeros((n_samples, self.n_classes_))
         for sample_idx in range(n_samples):
-            sample = self._xtest[sample_idx]
+            sample = X[sample_idx]
 
             descendant_product = np.ones(self.n_classes_)
             ancestor_product = np.ones(self.n_classes_)
@@ -121,8 +91,7 @@ class HieAODE(LazyHierarchicalFeatureSelector):
 
                 sample_sum[sample_idx] = np.add(sample_sum[sample_idx], feature_product)
 
-        y = np.argmax(sample_sum, axis=1)
-        return y if predict else np.array([])
+        return np.argmax(sample_sum, axis=1)
 
     def calculate_class_prior(self, sample, feature_idx, value):
         for c in range(self.n_classes_):

--- a/scihfs/selectors/hie_aode.py
+++ b/scihfs/selectors/hie_aode.py
@@ -1,8 +1,5 @@
 import networkx as nx
 import numpy as np
-from sklearn.utils.validation import check_is_fitted, validate_data
-
-from scihfs.helpers import check_bool_dtype
 
 from .lazyHierarchicalFeatureSelector import LazyHierarchicalFeatureSelector
 
@@ -35,9 +32,7 @@ class HieAODE(LazyHierarchicalFeatureSelector):
 
     def predict(self, X):
         """Predict the target value for each instance in X using HieAODE."""
-        check_is_fitted(self)
-        X = validate_data(self, X, reset=False)
-        check_bool_dtype(X)
+        X = self._check_and_validate(X)
         n_samples = X.shape[0]
         sample_sum = np.zeros((n_samples, self.n_classes_))
         for sample_idx in range(n_samples):

--- a/scihfs/selectors/hip.py
+++ b/scihfs/selectors/hip.py
@@ -1,46 +1,33 @@
-import numpy as np
-from sklearn.naive_bayes import BernoulliNB
-
 from .lazyHierarchicalFeatureSelector import LazyHierarchicalFeatureSelector
 
 
 class HIP(LazyHierarchicalFeatureSelector):
-    """
-    Select non-redundant features with the highest relevance following the algorithm proposed by Wan and Freitas.
+    """HIP (Hierarchical Information-Preserving): Lazy classifier from Wan et al., 2015, Algorithm 1.
+
+    Essentially a compression which keeps for each path only the most detailed
+    positive or the most abstract negative feature -- for the subset of
+    per-instance features.
     """
 
-    def select_and_predict(
-        self, predict=True, saveFeatures=False, estimator=BernoulliNB()
-    ):
-        """
-        Select features lazy for each test instance amd optionally predict target value of test instances.
-        The features are selected, so that for each testing instance in each path only the deepest positive
-        or the highest negative feature is preserved.
+    def _select_features_per_instance(self, x_row):
+        """Keep, per path, the deepest positive or highest negative feature.
 
         Parameters
         ----------
-        predict : bool
-            true if predictions shall be obtained.
-        saveFeatures : bool
-            true if features selected for each test instance shall be saved.
-        estimator : sklearn-compatible estimator
-            Estimator to use for predictions.
-
+        x_row : numpy array of shape (n_features,)
+            One test instance.
 
         Returns
         -------
-        predictions for test input samples, if predict = false, returns empty array.
+        instance_status : dict
+            The node->0/1 selection mask.
         """
-        predictions = np.array([])
-        for idx in range(len(self._xtest)):
-            self._get_nonredundant_features(idx)
-            if predict:
-                predictions = np.append(predictions, self._predict(idx, estimator)[0])
-            if saveFeatures:
-                self._features[idx] = np.array(list(self._instance_status.values()))
-            self._feature_length[idx] = len(
-                [nodes for nodes, status in self._instance_status.items() if status]
-            )
-            for node in self._hierarchy_graph:
-                self._instance_status[node] = 1
-        return predictions
+        instance_status = {node: 1 for node in self._hierarchy_graph}
+        for node in self._hierarchy_graph:
+            if x_row[node] == 1:
+                for anc in self._hierarchy_graph.predecessors(node):
+                    instance_status[anc] = 0
+            else:
+                for desc in self._hierarchy_graph.successors(node):
+                    instance_status[desc] = 0
+        return instance_status

--- a/scihfs/selectors/hnb.py
+++ b/scihfs/selectors/hnb.py
@@ -3,14 +3,15 @@
 import networkx as nx
 import numpy as np
 import scipy.sparse as sp
-from sklearn.naive_bayes import BernoulliNB
 
 from .lazyHierarchicalFeatureSelector import LazyHierarchicalFeatureSelector
 
 
 class HNB(LazyHierarchicalFeatureSelector):
-    """
-    Select the k non-redundant features with the highest relevance following the algorithm proposed by Wan and Freitas.
+    """HNB (Hierarchy Based Redundant Attribute Removal Naive Bayes) classifier from Wan & Freitas, 2013.
+
+    Selects the top-k non-redundant features in descending order of their
+    relevance, with redundancy removed along each path.
     """
 
     def __init__(
@@ -31,39 +32,9 @@ class HNB(LazyHierarchicalFeatureSelector):
         super().__init__(hierarchy)
         self.k = k
 
-    def select_and_predict(
-        self, predict=True, saveFeatures=False, estimator=BernoulliNB()
-    ):
-        """
-        Select features lazy for each test instance amd optionally predict target value of test instances.
-        It selects the top-k-ranked features, such that redundancy along each path is removed,
-        in descending order of their individual predictive power measured by their relevance defined in helpers.py.
+    def _fit(self, X, y):
+        self._compute_relevance(X, y)
+        self._sort_relevance()
 
-        Parameters
-        ----------
-        predict : bool
-            true if predictions shall be obtained.
-        saveFeatures : bool
-            true if features selected for each test instance shall be saved.
-        estimator : sklearn-compatible estimator
-            Estimator to use for predictions.
-
-
-        Returns
-        -------
-        predictions for test input samples, if predict = false, returns empty array.
-        """
-        predictions = np.array([])
-        for idx in range(len(self._xtest)):
-            self._get_nonredundant_features_relevance(idx)
-            self._get_top_k()
-            if predict:
-                predictions = np.append(predictions, self._predict(idx, estimator)[0])
-            if saveFeatures:
-                self._features[idx] = np.array(list(self._instance_status.values()))
-            self._feature_length[idx] = len(
-                [nodes for nodes, status in self._instance_status.items() if status]
-            )
-            for node in self._hierarchy_graph:
-                self._instance_status[node] = 1
-        return predictions
+    def _select_features_per_instance(self, x_row):
+        return self._get_top_k(self._get_nonredundant_features_relevance(x_row))

--- a/scihfs/selectors/hnbs.py
+++ b/scihfs/selectors/hnbs.py
@@ -1,45 +1,15 @@
-"HNB-select feature selection"
-
-import numpy as np
-from sklearn.naive_bayes import BernoulliNB
-
 from .lazyHierarchicalFeatureSelector import LazyHierarchicalFeatureSelector
 
 
 class HNBs(LazyHierarchicalFeatureSelector):
+    """HNB-s (Hierarchy Based Redundant Attribute Removal Naive Bayes without Selection Step) classifier proposed by Wan & Freitas, 2013.
+
+    Selects the non-redundant features such that redundancy along each path is
+    removed, using the per-node relevance.
     """
-    Select non-redundant features following the algorithm proposed by Wan and Freitas.
-    """
 
-    def select_and_predict(
-        self, predict=True, saveFeatures=False, estimator=BernoulliNB()
-    ):
-        """
-        Select features lazily for each test instance and optionally predict the target value of test instances.
-        It selects the features such that redundancy along each path is removed.
+    def _fit(self, X, y):
+        self._compute_relevance(X, y)
 
-        Parameters
-        ----------
-        predict : bool, default=True
-            Whether predictions should be obtained.
-        saveFeatures : bool, default=False
-            Whether features selected for each test instance should be saved.
-        estimator : sklearn-compatible estimator, default=BernoulliNB()
-            The estimator to use for predictions.
-
-        Returns
-        -------
-        np.ndarray
-            Predictions for test input samples. If `predict` is False, returns an empty array.
-        """
-        predictions = np.array([])
-        for idx in range(len(self._xtest)):
-            self._get_nonredundant_features_relevance(idx)
-            if predict:
-                predictions = np.append(predictions, self._predict(idx, estimator)[0])
-            if saveFeatures:
-                self._features[idx] = np.array(list(self._instance_status.values()))
-            self._feature_length[idx] = len(
-                [nodes for nodes, status in self._instance_status.items() if status]
-            )
-        return predictions
+    def _select_features_per_instance(self, x_row):
+        return self._get_nonredundant_features_relevance(x_row)

--- a/scihfs/selectors/lazyHierarchicalFeatureSelector.py
+++ b/scihfs/selectors/lazyHierarchicalFeatureSelector.py
@@ -135,11 +135,7 @@ class LazyHierarchicalFeatureSelector(
         self.n_classes_ = self.classes_.shape[0]
 
         self._fit_hierarchy(columns)
-        self._hierarchy_graph.remove_node("ROOT")
-        node_to_column = {
-            position: column for column, position in enumerate(self._columns)
-        }
-        self._hierarchy_graph = nx.relabel_nodes(self._hierarchy_graph, node_to_column)
+        self._relabel_hierarchy_to_columns()
 
         self._xtrain = X
         self._ytrain = y

--- a/scihfs/selectors/lazyHierarchicalFeatureSelector.py
+++ b/scihfs/selectors/lazyHierarchicalFeatureSelector.py
@@ -1,446 +1,386 @@
+"""Base class for lazy hierarchical feature selection classifiers."""
+
 from abc import ABC, abstractmethod
 
 import networkx as nx
 import numpy as np
-from sklearn.metrics import classification_report
+import scipy.sparse as sp
+from scipy.special import logsumexp
+from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.naive_bayes import BernoulliNB
-from sklearn.utils.validation import validate_data
+from sklearn.utils.validation import check_is_fitted, validate_data
 
-from scihfs.helpers import check_bool_dtype, check_data, get_relevance
-from scihfs.metrics import conditional_mutual_information
-from scihfs.selectors import HierarchicalEstimator
+from scihfs.helpers import check_binary_target, check_bool_dtype, get_relevance
+from scihfs.selectors.base import HierarchyMixin
 
 
-class LazyHierarchicalFeatureSelector(ABC, HierarchicalEstimator):
-    """
-    Abstract class used for all lazy hierarchical feature selection methods.
+class _MaskedBernoulliNB(BernoulliNB):
+    """A ``BernoulliNB`` that can score an instance on a feature subset.
 
-    Every method should implement the method select_and_predict.
-
-    Lazy selectors are arrays-only: unlike the ``HierarchicalPreprocessor``
-    and the eager selectors, they neither auto-derive the column->node
-    mapping from DataFrame feature names nor support the output API
-    (``get_feature_names_out`` / ``set_output``). Pass plain arrays to
-    ``fit_selector`` (with an explicit ``columns`` mapping when column
-    and node order differ); a DataFrame-aware lazy API is left to a
-    future redesign of the lazy interface.
+    Naive Bayes class for binary classification identical to sklearn's own, with the
+    only variation that it can score a single instance on a (masked) subset of the
+    features, and that it can store the precomputed "feature is 0" log-probabilities
+    for that scoring (instead of recomputing them on every instance).
     """
 
-    def fit(self, X, y=None):
-        """
-        Implementing the fit function for Sklearn compatibility.
+    def fit(self, X, y):
+        super().fit(X, y)
+        # Precompute the "feature is 0" log-probabilities.
+        self._neg_log_prob = np.log(1 - np.exp(self.feature_log_prob_))
+        return self
+
+    def predict_proba_masked(self, x_row, columns):
+        """Class probabilities for ``x_row`` (a single instance from the test set)
+        using only the selected ``columns``.
+
+        Calculates the joint log-likelihood of the fitted BernoulliNB on the selected
+        columns, then normalises it to yield probabilities over the two classes.
+        Required for predict_proba AND predict.
 
         Parameters
         ----------
-        X : {array-like, sparse matrix}, shape (n_samples, n_features)
-            The training input samples.
-        y : array-like, shape (n_samples,)
-            The target values. An array of int.
+        x_row : numpy array of shape (n_features,), bool
+            One test instance.
+        columns : list of int
+            The selected feature columns. An empty list means "no evidence" and yields
+            the training majority class.
+
+        Returns
+        -------
+        proba : numpy array of shape (n_classes,)
+            The normalised class probabilities, ordered by ``classes_`` (0,1).
+        """
+        x = x_row.astype(float)[columns]
+        pos = self.feature_log_prob_[:, columns]
+        neg = self._neg_log_prob[:, columns]
+        jll = self.class_log_prior_ + (x * pos + (1 - x) * neg).sum(axis=1)
+        return np.exp(jll - logsumexp(jll))
+
+
+class LazyHierarchicalFeatureSelector(
+    ClassifierMixin, HierarchyMixin, BaseEstimator, ABC
+):
+    """Abstract base class for lazy hierarchical feature-selection classifiers.
+
+    Lazy means that the classifiers work on a per-(test-)instance basis, like kNN.
+    Feature selection is embedded in these classification algorithms.
+    The API is congruent with scikit-learn's:
+    ``fit`` does the precomputation and all those steps that only need to be done once
+    per training set, while ``predict`` does the actual per-instance (selection and)
+    prediction.
+
+    Lazy selectors are arrays-only: unlike the ``HierarchicalPreprocessor`` and
+    the eager selectors they neither auto-derive the column->node mapping from
+    DataFrame feature names nor support the transformer output API. Pass plain
+    arrays (with an explicit ``columns`` mapping when column and node order
+    differ); DataFrame-aware lazy input is left to a future redesign of the lazy
+    interface.
+    """
+
+    def __init__(
+        self,
+        hierarchy: np.ndarray | sp.sparray | sp.spmatrix | nx.DiGraph | None = None,
+    ):
+        """Initializes a LazyHierarchicalFeatureSelector.
+
+        Parameters
+        ----------
+        hierarchy : np.ndarray, scipy.sparse array/matrix or nx.DiGraph
+            The hierarchy graph. See ``HierarchicalEstimator.__init__`` for the
+            accepted formats.
+        """
+        super().__init__(hierarchy)
+
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.classifier_tags.multi_class = False
+        return tags
+
+    def fit(self, X, y, columns=None):
+        """Fit the lazy classifier on the training data.
+
+        Builds the hierarchy, fits a Bernoulli naive Bayes on all training
+        columns and stores the training data; any computation of metrics or
+        structures that is necessary for the classification of all test instances
+        will need to be implemented in the subclasses' ``_fit`` (which is
+        called here).
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The training input samples. Must be bool-dtype.
+        y : array-like of shape (n_samples,)
+            The target values.
+        columns : list or None
+            The mapping from the hierarchy graph's nodes to the columns in X.
+            A list of ints; ``None`` assumes positional 1:1 ordering.
 
         Returns
         -------
         self : object
             Fitted estimator.
         """
-        X = validate_data(self, X, accept_sparse=True)
+        X, y = validate_data(self, X, y)
+        check_binary_target(y)
         check_bool_dtype(X)
-        if y is not None:
-            if not isinstance(y, np.ndarray):
-                try:
-                    y = np.asarray(y)
-                except Exception as e:
-                    raise ValueError(f"Invalid input for y: {e}")
-            self.n_classes_ = np.unique(y).shape[0]
+        self.classes_ = np.unique(y)
+        self.n_classes_ = self.classes_.shape[0]
 
+        self._fit_hierarchy(columns)
+        self._hierarchy_graph.remove_node("ROOT")
+        node_to_column = {
+            position: column for column, position in enumerate(self._columns)
+        }
+        self._hierarchy_graph = nx.relabel_nodes(self._hierarchy_graph, node_to_column)
+
+        self._xtrain = X
+        self._ytrain = y
+        # CAUTION: Calling the BernoulliNB could be shifted to the subclasses' ``_fit``
+        # in the future to allow replacement with other classifiers (if necessary).
+        self._nb = _MaskedBernoulliNB(binarize=None).fit(X, y)
+
+        self._fit(X, y)
+        self.is_fitted_ = True
         return self
 
-    def fit_selector(self, X_train, y_train, X_test, columns=None):
-        """
-        Fit LazyHierarchicalFeatureSelector class.
+    def _fit(self, X, y):
+        """Train-time hook for subclasses (default: no-op)."""
 
-        Due to laziness fitting of parameters as well
-        as predictions are obtained per instance.
+    def _compute_relevance(self, X, y):
+        """Precompute the per-node relevance from the training data.
+
+        Sets ``self._relevance`` (node -> relevance score). Called from the
+        ``_fit`` hook of only those selectors (subclasses) that rank features by
+        relevance. Those that don't, skip it.
 
         Parameters
         ----------
-        X_train : {numpy array} of shape (n_samples, n_features)
+        X : numpy array of shape (n_samples, n_features)
             The training input samples.
-        X_test : {numpy array} of shape (n_samples, n_features)
-            The test input samples.
-            converted into a sparse ``csc_matrix``.
-        y_train : array-like of shape (n_samples, n_levels)
-            The target values, i.e., hierarchical class labels for classification.
-
-        Raises
-        ------
-        ValueError
-            If X_train or X_test is not bool-dtype.
+        y : numpy array of shape (n_samples,)
+            The target values.
         """
-        check_bool_dtype(X_train)
-        check_bool_dtype(X_test)
-        # Create DAG
-        self.n_features_in_ = X_train.shape[1]
-        self.n_classes_ = np.unique(y_train).shape[0]
+        self._relevance = {
+            node: get_relevance(X, y, node) for node in self._hierarchy_graph
+        }
 
-        self._set_hierarchy()
-        self._hierarchy_graph.remove_node("ROOT")
-        if columns:
-            self._columns = columns
-        else:
-            self._columns = list(range(self.n_features_in_))
+    def _sort_relevance(self):
+        """Sort the hierarchy nodes by ascending relevance.
 
-        mapping = {value: index for index, value in enumerate(self._columns)}
-        self._hierarchy_graph = nx.relabel_nodes(self._hierarchy_graph, mapping)
-
-        self._xtrain = X_train
-        self._ytrain = y_train
-        self._xtest = X_test
-
-        self._features = np.zeros(shape=X_test.shape)
-        self._feature_length = np.zeros(self._xtest.shape[1], dtype=int)
-
-        # Validate data
-        check_data(self._hierarchy_graph, self._xtrain, self._ytrain)
-
-        # Get relevance of each node
-        self._relevance = {}
-        for node in self._hierarchy_graph:
-            self._relevance[node] = get_relevance(self._xtrain, self._ytrain, node)
+        Sets ``self._sorted_relevance``: The nodes from ``self._relevance`` ordered
+        by their values.
+        Requires ``_compute_relevance`` to have run first.
+        """
         self._sorted_relevance = sorted(self._relevance, key=self._relevance.get)
 
-        self._instance_status = {}
-        for node in self._hierarchy_graph:
-            self._instance_status[node] = 1
-
-    @abstractmethod
-    def select_and_predict(
-        self, predict=True, saveFeatures=False, estimator=BernoulliNB()
-    ):
-        """
-        Select features lazy for each test instance amd optionally predict target value of test instances.
-
-        To be implemented by children.
-
-        Parameters
-        ----------
-        predict :   {bool}
-            true if predictions shall be obtained.
-        saveFeatures : {bool}
-            true if features selected for each test instance shall be saved.
-        estimator : sklearn-compatible estimator.
-            Estimator to use for predictions.
+    def _check_and_validate(self, X):
+        """Shared function for input validation.
 
         Returns
         -------
-        predictions for test input samples
-            if predict = false, returns empty array
+        X : numpy array
+            The validated test input.
         """
-        pass
+        check_is_fitted(self)
+        X = validate_data(self, X, reset=False)
+        check_bool_dtype(X)
+        return X
 
-    def _get_nonredundant_features(self, idx):
-        """
-        Get nonredundant features without relevance score.
-
-        Basic functionality of the algorithm HIP proposed by Wan & Freitas.
+    def _select_and_predict_proba(self, X, return_masks):
+        """One per-instance sweep of selection + prediction.
 
         Parameters
         ----------
-        idx : int
-            Index of test instance for which the features shall be selected.
-        """
-        for node in self._hierarchy_graph:
-            self._instance_status[node] = 1
-        for node in self._hierarchy_graph:
-            if self._xtest[idx][node] == 1:
-                for anc in self._hierarchy_graph.predecessors(node):
-                    self._instance_status[anc] = 0
-            else:
-                for desc in self._hierarchy_graph.successors(node):
-                    self._instance_status[desc] = 0
+        X : numpy array of shape (n_samples, n_features)
+            The validated test input samples.
+        return_masks : bool
+            Whether to also build the per-instance selection masks.
 
-    def _get_nonredundant_features_relevance(self, idx):
+        Returns
+        -------
+        proba : numpy array of shape (n_samples, n_classes)
+            The per-instance class probabilities, columns ordered by ``classes_``.
+        masks : numpy array of shape (n_samples, n_features), dtype bool, or None
+            The per-instance selection masks when ``return_masks`` is set, else
+            ``None``.
         """
-        Get nonredundant features based on relevance score.
+        proba = np.empty((X.shape[0], self.n_classes_))
+        masks = (
+            np.zeros((X.shape[0], self.n_features_in_), dtype=bool)
+            if return_masks
+            else None
+        )
+        for idx in range(X.shape[0]):
+            status = self._select_features_per_instance(X[idx])
+            proba[idx] = self._predict_proba_per_instance(X[idx], status)
+            if return_masks:
+                for node, selected in status.items():
+                    # Nodes are data-column indices after fit's relabel.
+                    if selected:
+                        masks[idx, node] = True
+        return proba, masks
 
-        Basic functionality of the HNB algorithm proposed by Wan & Freitas.
+    def predict(self, X, return_masks=False):
+        """Predict the target value for each instance in X.
+
+        Argmaxes over the class probabilities per test instance.
+
+        In order to avoid writing the selected features to ``self`` on a per-instance basis,
+        this function allows the return of the selection masks ("the selected features") as
+        a dedicated variable when ``return_masks`` is set to True (default False).
 
         Parameters
         ----------
-        idx :
-            Index of test instance for which the features shall be selected.
+        X : array-like of shape (n_samples, n_features)
+            The test input samples. Must be bool-dtype.
+        return_masks : bool, default=False
+            If True, also return the per-instance selection masks, built in the
+            same sweep as the predictions (so both come from one pass instead of a
+            separate ``select`` call). The masks are identical to ``select(X)``.
+
+        Returns
+        -------
+        predictions : numpy array of shape (n_samples,)
+            The predicted target values.
+        masks : numpy array of shape (n_samples, n_features), dtype bool
+            Returned only when ``return_masks`` is True; ``masks[i, j]`` is True
+            iff feature column ``j`` was selected for test instance ``i``.
         """
+        X = self._check_and_validate(X)
+        proba, masks = self._select_and_predict_proba(X, return_masks=return_masks)
+        predictions = self.classes_[np.argmax(proba, axis=1)]
+        if return_masks:
+            return predictions, masks
+        return predictions
+
+    def predict_proba(self, X):
+        """Class probabilities for each (test) instance in X.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The test input samples. Must be bool-dtype.
+
+        Returns
+        -------
+        proba : numpy array of shape (n_samples, n_classes)
+            The class probabilities, columns ordered by ``classes_`` (0,1).
+        """
+        X = self._check_and_validate(X)
+        proba, _ = self._select_and_predict_proba(X, return_masks=False)
+        return proba
+
+    def select(self, X):
+        """Return the per-instance selected-feature masks for X.
+
+        The introspective counterpart to ``predict``: it runs the same
+        per-instance selection but returns the boolean masks instead of
+        predictions, without scoring the naive Bayes. Equivalent to the masks
+        from ``predict(X, return_masks=True)``.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The test input samples. Must be bool-dtype.
+
+        Returns
+        -------
+        masks : numpy array of shape (n_samples, n_features), dtype bool
+            ``masks[i, j]`` is True iff feature column ``j`` was selected for
+            test instance ``i``.
+        """
+        X = self._check_and_validate(X)
+        masks = np.zeros((X.shape[0], self.n_features_in_), dtype=bool)
+        for idx in range(X.shape[0]):
+            for node, selected in self._select_features_per_instance(X[idx]).items():
+                # Nodes are data-column indices after fit's relabel.
+                if selected:
+                    masks[idx, node] = True
+        return masks
+
+    @abstractmethod
+    def _select_features_per_instance(self, x_row):
+        """Select the features for a single test instance.
+
+        Parameters
+        ----------
+        x_row : numpy array of shape (n_features,)
+            One test instance.
+
+        Returns
+        -------
+        instance_status : dict
+            Maps each hierarchy node to 1 (selected) or 0 (not selected).
+        """
+
+    def _predict_proba_per_instance(self, x_row, instance_status):
+        """Class probabilities for one instance.
+
+        Scores ``x_row`` against the fitted masked ``BernoulliNB`` on only the
+        selected columns. After ``fit``'s relabel the hierarchy nodes are already
+        data-column indices, so the selected nodes index the classifier directly.
+        An empty selection scores on the class prior alone, i.e. yields the
+        training class priors (whose argmax is the majority class).
+
+        Parameters
+        ----------
+        x_row : numpy array of shape (n_features,)
+            The test instance to classify.
+        instance_status : dict
+            The node->0/1 selection mask for this instance.
+
+        Returns
+        -------
+        proba : numpy array of shape (n_classes,)
+            The normalised class probabilities, ordered by ``classes_`` (0,1).
+        """
+        columns = [node for node, selected in instance_status.items() if selected]
+        return self._nb.predict_proba_masked(x_row, columns)
+
+    def _get_nonredundant_features_relevance(self, x_row):
+        """Get nonredundant features based on relevance score.
+
+        Basic functionality of HNB, but also required in other classifiers.
+
+        Parameters
+        ----------
+        x_row : numpy array of shape (n_features,)
+            One test instance.
+
+        Returns
+        -------
+        instance_status : dict
+            The node->0/1 selection mask.
+        """
+        instance_status = {node: 1 for node in self._hierarchy_graph}
         for node in self._hierarchy_graph:
-            self._instance_status[node] = 1
-        for node in self._hierarchy_graph:
-            if node == "ROOT":
-                continue
-            if self._xtest[idx][node] == 1:
+            if x_row[node] == 1:
                 for anc in nx.ancestors(self._hierarchy_graph, node):
                     if self._relevance[anc] <= self._relevance[node]:
-                        self._instance_status[anc] = 0
+                        instance_status[anc] = 0
             else:
                 for desc in nx.descendants(self._hierarchy_graph, node):
                     if self._relevance[desc] <= self._relevance[node]:
-                        self._instance_status[desc] = 0
+                        instance_status[desc] = 0
+        return instance_status
 
-    def _get_nonredundant_features_mr(self, idx):
-        """
-        Get nonredundant features based on the MR considering all pathes.
-
-        Basic functionality of the HIP algorithm proposed by Wan & Freitas.
+    def _get_top_k(self, instance_status):
+        """Keep only the k highest-ranked of the selected features (ranked by relevance).
 
         Parameters
         ----------
-        idx :
-            Index of test instance for which the features shall be selected.
-        """
+        instance_status : dict
+            The node->0/1 selection mask to prune in place.
 
-        top_sort = list(nx.topological_sort(self._hierarchy_graph))
-        reverse_top_sort = reversed(top_sort)
-        mr = {}
-
-        for node in top_sort:
-            # correctness: as each predecessor lies on the same path as the current node
-            # one can be removed.
-            #
-            # not several nodes per path:
-            # contradiction - nodes a and b (a<b) selected and are on the same path.
-            # each node a+1..b-1 between would save a as most relevant node:
-            # 0: mr[a] = a
-            # 1: mr[a+1] = a+1, if rel[mr[pred]=a] > rel[mr[a+1]=a+1]: mr[a+1]=a
-            # and status[a+1] = remove
-            # i: mr[a+i] = a+i, if rel[mr[pred]=a] > rel[mr[a+i]=a+i]: mr[a+i]=a
-            # and status[a+i] = remove
-            # When b is processed, mr[b-1] = a, so either rel[a]>rel[b] -> mr[b]=b is removed
-            # and set to a OR mr[b-1]=a is removed and mr[b] stays b.
-            #
-            # at least one node per path: As there is a maximum relevant node in each path
-            # this node will stay mr[node] = node and not be exchanged through mr[pred].
-            # Then the condition is never met on this path
-            # so self._instance_status[mr[node]] = 0 never executed.
-            #
-            mr[node] = []
-            more_rel_nodes = [node]
-            if self._xtest[idx][node]:
-                # preds are 1 because of 0-1-propagation
-                for pred in self._hierarchy_graph.predecessors(node):
-                    # get most relevant nodes seen on the paths until current node
-                    for _mr in mr[pred]:
-                        # if their is a node on the path more important then current node
-                        if self._relevance[_mr] > self._relevance[node]:
-                            self._instance_status[node] = 0
-                            # save this node for next iterations (steps on path)
-                            more_rel_nodes.append(_mr)
-                        else:
-                            # save current node as most important.
-                            # there can be several paths, in this case, several nodes are saved
-                            self._instance_status[_mr] = 0
-                            more_rel_nodes.append(node)
-            mr[node] = more_rel_nodes
-
-        for node in reverse_top_sort:
-            mr[node] = []
-            more_rel_nodes = [node]
-            if not self._xtest[idx][node]:
-                mr[node] = node
-                for suc in self._hierarchy_graph.successors(node):
-                    # get most relevant nodes seen on paths until current node
-                    for _mr in mr[suc]:
-                        if self._relevance[_mr] > self._relevance[node]:
-                            # each node not selected will removed
-                            self._instance_status[node] = 0
-                            more_rel_nodes.append(_mr)
-                        else:
-                            self._instance_status[_mr] = 0
-                            more_rel_nodes.append(node)
-            mr[node] = more_rel_nodes
-
-    def _get_top_k(self):
-        """
-        Get k highest-ranked features by relevance.
+        Returns
+        -------
+        instance_status : dict
+            The pruned mask.
         """
         counter = 0
         for node in reversed(self._sorted_relevance):
-            if node == "ROOT":
-                continue
-            if (counter < self.k or not self.k) and self._instance_status[node]:
+            if (counter < self.k or not self.k) and instance_status[node]:
                 counter += 1
             else:
-                self._instance_status[node] = 0
-
-    def _build_mst(self):
-        """
-        Build minium spanning tree for each possible edge in the feature tree.
-        """
-        self._edge_status = np.zeros((self.n_features_in_, self.n_features_in_))
-        self._cmi = np.zeros((self.n_features_in_, self.n_features_in_))
-        self._sorted_edges = []
-        for node1 in self._hierarchy_graph.nodes:
-            for node2 in self._hierarchy_graph.nodes:
-                if node1 == node2:
-                    continue
-                self._cmi[node1][node2] = conditional_mutual_information(
-                    self._xtrain[:, node1], self._xtrain[:, node2], self._ytrain
-                )
-                self._edge_status[node1][node2] = 1
-        sorted_indices = np.argsort(self._cmi, axis=None)
-        for index in sorted_indices:
-            coordinates = divmod(index, self.n_features_in_)
-
-            if coordinates[0] < coordinates[1]:
-                self._sorted_edges.append(coordinates)
-
-    def _get_nonredundant_features_from_mst(self, idx):
-        """
-        Get nonredundant features from MST.
-
-        Basic functionality of the algorithm TAN proposed by Wan & Freitas.
-
-        Parameters
-        ----------
-        idx : int
-            Index of test instance for which the features shall be selected.
-        """
-        UDAG = nx.Graph()
-
-        for node1 in self._hierarchy_graph:
-            self._instance_status[node1] = 0
-            for node2 in self._hierarchy_graph:
-                self._edge_status[node1][node2] = 1
-
-        representants = [i for i in range(self.n_features_in_)]
-        members = {}
-        for i in range(self.n_features_in_):
-            members[i] = [i]
-
-        # get paths
-        reachable_nodes = {}
-        for node in self._hierarchy_graph:
-            reachable_nodes[node] = []
-            for des in nx.descendants(self._hierarchy_graph, node):
-                reachable_nodes[node].append(des)
-        # select edges
-        for edge in self._sorted_edges:
-            if (
-                self._edge_status[edge[0]][edge[1]]
-                # check redundancy: same path and same value
-                and (
-                    self._xtest[idx][edge[0]] != self._xtest[idx][edge[1]]
-                    or (
-                        edge[0] not in reachable_nodes[edge[1]]
-                        and edge[1] not in reachable_nodes[edge[1]]
-                    )
-                )
-                # check if circle in UDAG using the property, that edge (a,b) infers circle iff a und b
-                # are members of the same component
-                and representants[edge[0]] != representants[edge[1]]
-            ):
-                UDAG.add_edge(edge[0], edge[1])
-                self._edge_status[edge[0]][edge[1]] = 0
-
-                # merge: change the representatives of the smaller component
-                if len(members[representants[edge[0]]]) <= len(
-                    members[representants[edge[1]]]
-                ):
-                    for m in members[edge[0]]:
-                        representants[m] = representants[edge[1]]
-                        members[representants[edge[1]]].append(m)
-                else:
-                    for m in members[edge[1]]:
-                        representants[m] = representants[edge[0]]
-                        members[representants[edge[0]]].append(m)
-
-                # remove all edges with redundant ancestors or descendants of e0 and e1
-                for selected_node in [edge[0], edge[1]]:
-                    for neighbor_node in nx.ancestors(
-                        self._hierarchy_graph, selected_node
-                    ):
-                        if (
-                            self._xtest[idx][selected_node]
-                            == self._xtest[idx][neighbor_node]
-                        ):
-                            # alternative: collect all and then delete in sorted_edges
-                            self._edge_status[:, neighbor_node] = 0
-                            self._edge_status[neighbor_node][:] = 0
-                    for neighbor_node in nx.descendants(
-                        self._hierarchy_graph, selected_node
-                    ):
-                        if (
-                            self._xtest[idx][selected_node]
-                            == self._xtest[idx][neighbor_node]
-                        ):
-                            self._edge_status[:, neighbor_node] = 0
-                            self._edge_status[neighbor_node][:] = 0
-
-                self._instance_status[edge[0]] = 1
-                self._instance_status[edge[1]] = 1
-
-    def _predict(self, idx, estimator):
-        """
-        Predicts for an instance of the test set.
-
-        Parameters
-        ----------
-        idx : int
-            Index of test instance which shall be predicted.
-        estimator : sklearn-compatible estimator
-                    Estimator to use for predictions.
-
-        Returns
-        -------
-        prediction : bool
-            prediction of test instance's target value.
-        """
-        features = [nodes for nodes, status in self._instance_status.items() if status]
-        features_in_dataset = []
-        for feature in features:
-            features_in_dataset.append(self._columns.index(feature))
-        clf = estimator
-        clf.fit(self._xtrain[:, features_in_dataset], self._ytrain)
-        return clf.predict(self._xtest[idx][features_in_dataset].reshape(1, -1))
-
-    def get_score(self, ytest, predictions):
-        """
-        Returns score of the predictions.
-
-        Note that recall of the positive class is known as “sensitivity”;
-        recall of the negative class is “specificity”
-
-        Parameters
-        ----------
-        ytest : 1d array-like, or label indicator array / sparse matrix
-            truth values of y.
-        predictions : 1d array-like, or label indicator array / sparse matrix
-            obtained predictions.
-
-        Returns
-        -------
-        report : dict
-            metrics of prediction.
-        """
-        avg_feature_length = 0
-        for idx in range(0, self._xtest.shape[0] - 1):
-            avg_feature_length += self._feature_length[idx] / self._xtrain.shape[1]
-        avg_feature_length = avg_feature_length / (len(self._feature_length))
-        score = classification_report(y_true=ytest, y_pred=predictions, output_dict=True)
-        score["sensitivityxspecificity"] = float(score["0"]["recall"]) * float(
-            score["1"]["recall"]
-        )
-        score["compression"] = avg_feature_length
-
-        return score
-
-    def get_features(self):
-        """
-        Get selected features.
-
-        Parameters
-        ----------
-        None
-
-        Returns
-        -------
-        features : numpy array
-            Boolean value at index states if feature is selected.
-        """
-        return self._features
+                instance_status[node] = 0
+        return instance_status

--- a/scihfs/selectors/lazyHierarchicalFeatureSelector.py
+++ b/scihfs/selectors/lazyHierarchicalFeatureSelector.py
@@ -94,6 +94,7 @@ class LazyHierarchicalFeatureSelector(
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
         tags.classifier_tags.multi_class = False
+        tags.input_tags.sparse = True
         return tags
 
     def fit(self, X, y, columns=None):
@@ -107,8 +108,9 @@ class LazyHierarchicalFeatureSelector(
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
-            The training input samples. Must be bool-dtype.
+        X : array-like or scipy.sparse (CSR) of shape (n_samples, n_features)
+            The training input samples. Must be bool-dtype. Sparse input is
+            densified internally (for now).
         y : array-like of shape (n_samples,)
             The target values.
         columns : list or None
@@ -120,8 +122,10 @@ class LazyHierarchicalFeatureSelector(
         self : object
             Fitted estimator.
         """
-        X, y = validate_data(self, X, y)
+        X, y = validate_data(self, X, y, accept_sparse="csr")
         check_binary_target(y)
+        if sp.issparse(X):
+            X = X.toarray()
         check_bool_dtype(X)
         self.classes_ = np.unique(y)
         self.n_classes_ = self.classes_.shape[0]
@@ -176,13 +180,19 @@ class LazyHierarchicalFeatureSelector(
     def _check_and_validate(self, X):
         """Shared function for input validation.
 
+        Sparse input (CSR) is accepted and densified: the per-instance selection
+        algorithms index single rows as dense, so the classifiers accept sparse
+        at the boundary but work on a dense copy internally.
+
         Returns
         -------
         X : numpy array
-            The validated test input.
+            The validated (and densified) test input.
         """
         check_is_fitted(self)
-        X = validate_data(self, X, reset=False)
+        X = validate_data(self, X, accept_sparse="csr", reset=False)
+        if sp.issparse(X):
+            X = X.toarray()
         check_bool_dtype(X)
         return X
 

--- a/scihfs/selectors/lazyHierarchicalFeatureSelector.py
+++ b/scihfs/selectors/lazyHierarchicalFeatureSelector.py
@@ -69,12 +69,12 @@ class LazyHierarchicalFeatureSelector(
     per training set, while ``predict`` does the actual per-instance (selection and)
     prediction.
 
-    Lazy selectors are arrays-only: unlike the ``HierarchicalPreprocessor`` and
-    the eager selectors they neither auto-derive the column->node mapping from
-    DataFrame feature names nor support the transformer output API. Pass plain
-    arrays (with an explicit ``columns`` mapping when column and node order
-    differ); DataFrame-aware lazy input is left to a future redesign of the lazy
-    interface.
+    Input can be a plain ndarray, a ``scipy.sparse`` (CSR) matrix, or a pandas
+    ``DataFrame``.
+    Note that a ``DataFrame`` X together with a named ``nx.DiGraph`` hierarchy
+    auto-derives the column->node mapping from the feature names; otherwise an
+    explicit ``columns`` mapping needs to be provided (fallback is the positional 1:1
+    default).
     """
 
     def __init__(
@@ -115,7 +115,11 @@ class LazyHierarchicalFeatureSelector(
             The target values.
         columns : list or None
             The mapping from the hierarchy graph's nodes to the columns in X.
-            A list of ints; ``None`` assumes positional 1:1 ordering.
+            A list of ints. If ``None`` the columns in X and the hierarchy nodes
+            are assumed to be in the same order -- with the only exception that
+            when X is passed as a ``DataFrame`` and the hierarchy is a named
+            ``nx.DiGraph``, the mapping is auto-derived from the feature names (see
+            ``_auto_derive_columns``).
 
         Returns
         -------

--- a/scihfs/selectors/mr.py
+++ b/scihfs/selectors/mr.py
@@ -1,48 +1,90 @@
 "MR-select feature selection"
 
-import numpy as np
-from sklearn.naive_bayes import BernoulliNB
+import networkx as nx
 
 from .lazyHierarchicalFeatureSelector import LazyHierarchicalFeatureSelector
 
 
 class MR(LazyHierarchicalFeatureSelector):
-    """
-    Select non-redundant features with the highest relevance on each path following the algorithm proposed by Wan and Freitas
+    """MR (Most Relevant): Lazy classifier from Wan et al., 2015, Algorithm 2.
+
+    Selects, for each path, the most relevant non-redundant features following
+    the per-node relevance score.
     """
 
-    def select_and_predict(
-        self, predict=True, saveFeatures=False, estimator=BernoulliNB()
-    ):
-        """
-        Select features lazy for each test instance amd optionally predict target value of test instances.
-        The features are selected such that for each path only the most relevant features are preserved
-        following the relevance score defined in helpers.py.
+    def _fit(self, X, y):
+        self._compute_relevance(X, y)
+
+    def _select_features_per_instance(self, x_row):
+        """Select, per path, the most relevant non-redundant features.
 
         Parameters
         ----------
-        predict :  bool
-            true if predictions shall be obtained
-        saveFeatures : bool
-            true if features selected for each test instance shall be saved.
-        estimator : sklearn-compatible estimator
-            Estimator to use for predictions
-
+        x_row : numpy array of shape (n_features,)
+            One test instance.
 
         Returns
         -------
-        predictions for test input samples, if predict = false, returns empty array
+        instance_status : dict
+            The node->0/1 selection mask.
         """
-        predictions = np.array([])
-        for idx in range(len(self._xtest)):
-            self._get_nonredundant_features_mr(idx)
-            if predict:
-                predictions = np.append(predictions, self._predict(idx, estimator)[0])
-            if saveFeatures:
-                self._features[idx] = np.array(list(self._instance_status.values()))
-            self._feature_length[idx] = len(
-                [nodes for nodes, status in self._instance_status.items() if status]
-            )
-            for node in self._hierarchy_graph:
-                self._instance_status[node] = 1
-        return predictions
+        instance_status = {node: 1 for node in self._hierarchy_graph}
+        top_sort = list(nx.topological_sort(self._hierarchy_graph))
+        reverse_top_sort = reversed(top_sort)
+        mr = {}
+
+        for node in top_sort:
+            # correctness: as each predecessor lies on the same path as the current node
+            # one can be removed.
+            #
+            # not several nodes per path:
+            # contradiction - nodes a and b (a<b) selected and are on the same path.
+            # each node a+1..b-1 between would save a as most relevant node:
+            # 0: mr[a] = a
+            # 1: mr[a+1] = a+1, if rel[mr[pred]=a] > rel[mr[a+1]=a+1]: mr[a+1]=a
+            # and status[a+1] = remove
+            # i: mr[a+i] = a+i, if rel[mr[pred]=a] > rel[mr[a+i]=a+i]: mr[a+i]=a
+            # and status[a+i] = remove
+            # When b is processed, mr[b-1] = a, so either rel[a]>rel[b] -> mr[b]=b is removed
+            # and set to a OR mr[b-1]=a is removed and mr[b] stays b.
+            #
+            # at least one node per path: As there is a maximum relevant node in each path
+            # this node will stay mr[node] = node and not be exchanged through mr[pred].
+            # Then the condition is never met on this path
+            # so instance_status[mr[node]] = 0 never executed.
+            #
+            mr[node] = []
+            more_rel_nodes = [node]
+            if x_row[node]:
+                # preds are 1 because of 0-1-propagation
+                for pred in self._hierarchy_graph.predecessors(node):
+                    # get most relevant nodes seen on the paths until current node
+                    for _mr in mr[pred]:
+                        # if there is a node on the path more important than current node
+                        if self._relevance[_mr] > self._relevance[node]:
+                            instance_status[node] = 0
+                            # save this node for next iterations (steps on path)
+                            more_rel_nodes.append(_mr)
+                        else:
+                            # save current node as most important.
+                            # there can be several paths, in this case, several nodes are saved
+                            instance_status[_mr] = 0
+                            more_rel_nodes.append(node)
+            mr[node] = more_rel_nodes
+
+        for node in reverse_top_sort:
+            mr[node] = []
+            more_rel_nodes = [node]
+            if not x_row[node]:
+                for suc in self._hierarchy_graph.successors(node):
+                    # get most relevant nodes seen on paths until current node
+                    for _mr in mr[suc]:
+                        if self._relevance[_mr] > self._relevance[node]:
+                            # each node not selected will be removed
+                            instance_status[node] = 0
+                            more_rel_nodes.append(_mr)
+                        else:
+                            instance_status[_mr] = 0
+                            more_rel_nodes.append(node)
+            mr[node] = more_rel_nodes
+        return instance_status

--- a/scihfs/selectors/rnb.py
+++ b/scihfs/selectors/rnb.py
@@ -3,15 +3,15 @@
 import networkx as nx
 import numpy as np
 import scipy.sparse as sp
-from sklearn.naive_bayes import BernoulliNB
 
 from .lazyHierarchicalFeatureSelector import LazyHierarchicalFeatureSelector
 
 
 class RNB(LazyHierarchicalFeatureSelector):
-    """
-    Select the k features with the highest relevance.
+    """RNB (Relevance-based Naive Bayes): Lazy classifier from Wan & Freitas, 2013.
 
+    Selects the k features with the highest relevance (the same subset for
+    every test instance).
     """
 
     def __init__(
@@ -19,7 +19,7 @@ class RNB(LazyHierarchicalFeatureSelector):
         hierarchy: np.ndarray | sp.sparray | sp.spmatrix | nx.DiGraph | None = None,
         k=0,
     ):
-        """Initializes a RNB-Selector.
+        """Initializes an RNB-Selector.
 
         Parameters
         ----------
@@ -32,34 +32,9 @@ class RNB(LazyHierarchicalFeatureSelector):
         super().__init__(hierarchy)
         self.k = k
 
-    def select_and_predict(
-        self, predict=True, saveFeatures=False, estimator=BernoulliNB()
-    ):
-        """
-        Select features lazy for each test instance amd optionally predict target value of test instances.
-        It selects the top-k-ranked features in descending order of their individual predictive power measured by their relevance defined in helpers.py
+    def _fit(self, X, y):
+        self._compute_relevance(X, y)
+        self._sort_relevance()
 
-        Parameters
-        ----------
-        predict : bool
-            true if predictions shall be obtained.
-        saveFeatures : bool
-            true if features selected for each test instance shall be saved.
-        estimator : sklearn-compatible estimator
-            Estimator to use for predictions.
-
-        Returns
-        -------
-        predictions for test input samples, if predict = false, returns empty array.
-        """
-        predictions = np.array([])
-        for idx in range(len(self._xtest)):
-            self._get_top_k()  # change as equal for each test instance
-            if predict:
-                predictions = np.append(predictions, self._predict(idx, estimator)[0])
-            if saveFeatures:
-                self._features[idx] = np.array(list(self._instance_status.values()))
-            self._feature_length[idx] = len(
-                [nodes for nodes, status in self._instance_status.items() if status]
-            )
-        return predictions
+    def _select_features_per_instance(self, x_row):
+        return self._get_top_k({node: 1 for node in self._hierarchy_graph})

--- a/scihfs/selectors/tan.py
+++ b/scihfs/selectors/tan.py
@@ -35,7 +35,10 @@ class TAN(LazyHierarchicalFeatureSelector):
                 self._cmi[node1][node2] = conditional_mutual_information(
                     self._xtrain[:, node1], self._xtrain[:, node2], self._ytrain
                 )
-        sorted_indices = np.argsort(self._cmi, axis=None)
+        # The resolution of tied CMI values is architecture-dependent
+        # (difference between x86 and arm64 observed). A stable sort
+        # yields deterministic behavior.
+        sorted_indices = np.argsort(self._cmi, axis=None, kind="stable")
         for index in sorted_indices:
             coordinates = divmod(index, self.n_features_in_)
             if coordinates[0] < coordinates[1]:

--- a/scihfs/selectors/tan.py
+++ b/scihfs/selectors/tan.py
@@ -1,48 +1,117 @@
-"HNB-select feature selection"
+"TAN feature selection"
 
+import networkx as nx
 import numpy as np
-from sklearn.naive_bayes import BernoulliNB
+
+from scihfs.metrics import conditional_mutual_information
 
 from .lazyHierarchicalFeatureSelector import LazyHierarchicalFeatureSelector
 
 
 class TAN(LazyHierarchicalFeatureSelector):
-    """
-    Select non-redundant features following the algorithm proposed by Wan and Freitas.
+    """Lazy TAN classifier (Wan & Freitas). TODO: Insert reference.
+
+    Builds a minimum spanning tree over the feature graph from the training
+    data (conditional mutual information), then selects, per test instance, the
+    non-redundant most-relevant features from that tree.
     """
 
-    def select_and_predict(
-        self, predict=True, saveFeatures=False, estimator=BernoulliNB()
-    ):
+    def _fit(self, X, y):
+        self._build_mst()
+
+    def _build_mst(self):
+        """Build the minimum spanning tree edges for the feature tree (train-only).
+
+        Computes the conditional mutual information of every ordered node pair
+        and the resulting relevance-sorted edge list ``self._sorted_edges``,
+        both derived purely from the training data.
         """
-        Select features lazy for each test instance amd optionally predict target value of test instances.
-        It builds a minimal spanning tree (MST), by first adding all possible edges,
-        that meets certain conditions (to remove redundancy and selecting most relevant features) to an undirected graph (UDAG).
-        Afterwards features are obtained from the tree and can be used for prediction.
+        self._cmi = np.zeros((self.n_features_in_, self.n_features_in_))
+        self._sorted_edges = []
+        for node1 in self._hierarchy_graph.nodes:
+            for node2 in self._hierarchy_graph.nodes:
+                if node1 == node2:
+                    continue
+                self._cmi[node1][node2] = conditional_mutual_information(
+                    self._xtrain[:, node1], self._xtrain[:, node2], self._ytrain
+                )
+        sorted_indices = np.argsort(self._cmi, axis=None)
+        for index in sorted_indices:
+            coordinates = divmod(index, self.n_features_in_)
+            if coordinates[0] < coordinates[1]:
+                self._sorted_edges.append(coordinates)
+
+    def _select_features_per_instance(self, x_row):
+        """Select the non-redundant most-relevant features from the MST.
 
         Parameters
         ----------
-        predict : bool
-            true if predictions shall be obtained.
-        saveFeatures : bool
-            true if features selected for each test instance shall be saved.
-        estimator : sklearn-compatible estimator
-            Estimator to use for predictions.
-
+        x_row : numpy array of shape (n_features,)
+            One test instance.
 
         Returns
         -------
-        predictions for test input samples, if predict = false, returns empty array.
+        instance_status : dict
+            The node->0/1 selection mask.
         """
-        predictions = np.array([])
-        self._build_mst()
-        for idx in range(len(self._xtest)):
-            self._get_nonredundant_features_from_mst(idx)
-            if predict:
-                predictions = np.append(predictions, self._predict(idx, estimator)[0])
-            if saveFeatures:
-                self._features[idx] = np.array(list(self._instance_status.values()))
-            self._feature_length[idx] = len(
-                [nodes for nodes, status in self._instance_status.items() if status]
-            )
-        return predictions
+        n_features = self.n_features_in_
+        instance_status = {node: 0 for node in self._hierarchy_graph}
+        edge_status = np.ones((n_features, n_features))
+
+        representants = [i for i in range(n_features)]
+        members = {i: [i] for i in range(n_features)}
+
+        # get paths
+        reachable_nodes = {
+            node: list(nx.descendants(self._hierarchy_graph, node))
+            for node in self._hierarchy_graph
+        }
+        # select edges
+        for edge in self._sorted_edges:
+            if (
+                edge_status[edge[0]][edge[1]]
+                # check redundancy: same path and same value
+                and (
+                    x_row[edge[0]] != x_row[edge[1]]
+                    or (
+                        edge[0] not in reachable_nodes[edge[1]]
+                        and edge[1] not in reachable_nodes[edge[1]]
+                    )
+                )
+                # check if circle in UDAG using the property, that edge (a,b) infers circle iff a und b
+                # are members of the same component
+                and representants[edge[0]] != representants[edge[1]]
+            ):
+                edge_status[edge[0]][edge[1]] = 0
+
+                # merge: change the representatives of the smaller component
+                if len(members[representants[edge[0]]]) <= len(
+                    members[representants[edge[1]]]
+                ):
+                    for m in members[edge[0]]:
+                        representants[m] = representants[edge[1]]
+                        members[representants[edge[1]]].append(m)
+                else:
+                    for m in members[edge[1]]:
+                        representants[m] = representants[edge[0]]
+                        members[representants[edge[0]]].append(m)
+
+                # remove all edges with redundant ancestors or descendants of e0 and e1
+                for selected_node in [edge[0], edge[1]]:
+                    for neighbor_node in nx.ancestors(
+                        self._hierarchy_graph, selected_node
+                    ):
+                        if x_row[selected_node] == x_row[neighbor_node]:
+                            # alternative: collect all and then delete in sorted_edges
+                            edge_status[:, neighbor_node] = 0
+                            edge_status[neighbor_node][:] = 0
+                    for neighbor_node in nx.descendants(
+                        self._hierarchy_graph, selected_node
+                    ):
+                        if x_row[selected_node] == x_row[neighbor_node]:
+                            edge_status[:, neighbor_node] = 0
+                            edge_status[neighbor_node][:] = 0
+
+                instance_status[edge[0]] = 1
+                instance_status[edge[1]] = 1
+        return instance_status

--- a/scihfs/tests/_estimators.py
+++ b/scihfs/tests/_estimators.py
@@ -4,16 +4,13 @@ In order to route the estimators to the correct tests, they are sorted based on
 their properties.
 
 - ``ALL_ESTIMATORS`` - they expose the full sklearn estimator surface, and can
-    be run through the sklearn conformance test suite. (Union of the eager and
-    lazy selectors, plus the base classes and the preprocessor. The abstract
-    eager base is represented by the minimal concrete stub
-    ``_MinimalEagerSelector``.)
-- ``EAGER_SELECTORS`` - single pass fit().
-- ``LAZY_SELECTORS`` - fit_selector() with both X_train and X_test to fit per
-    test instance.
+    be run through the sklearn conformance test suite. (The eager transformers
+    plus the lazy classifiers, plus the base classes and the preprocessor. The
+    abstract eager base is represented by the minimal concrete stub
+    ``_MinimalEagerSelector``.
 
-Future work: Divide by filter/wrapper/embedded feature selection methods when
-the embedded methods also inherit from ClassifierMixin.
+- ``EAGER_SELECTORS`` - transformers with a single-pass ``fit`` + ``transform``.
+- ``LAZY_SELECTORS`` - per-instance classifiers (``fit`` then ``predict``), all ``ClassifierMixin`` subclasses.
 """
 
 from scihfs import (
@@ -62,6 +59,7 @@ ALL_ESTIMATORS = [
     RNB,
     MR,
     HIP,
+    TAN,
     BottomUpSelector,
     GreedyTopDownSelector,
 ]

--- a/scihfs/tests/test_common.py
+++ b/scihfs/tests/test_common.py
@@ -8,8 +8,8 @@ from scihfs.tests._estimators import EAGER_SELECTORS, LAZY_SELECTORS
 # TEMPORARY FILE CONTENT WARNING:
 #
 # At the moment, the scope of this file is only to test the rejection of
-# non-bool-dtype input to the selectors. All sklearn-related tests are in
-# test_sklearn_conformance.py for now.
+# non-bool-dtype X input and non-binary y input to the selectors. All sklearn-
+# related tests are in test_sklearn_conformance.py for now.
 #
 # In the future, this file should contain all those tests that apply to
 # ALL estimators alike. Right now, a lot of these are scattered throughout
@@ -19,6 +19,11 @@ from scihfs.tests._estimators import EAGER_SELECTORS, LAZY_SELECTORS
 _HIERARCHY = nx.to_numpy_array(nx.DiGraph([(0, 1), (1, 2), (0, 3)]))
 _X_BOOL = np.array([[0, 1, 0, 1], [1, 0, 1, 0], [0, 0, 1, 1], [1, 1, 0, 0]], dtype=bool)
 _Y = np.array([0, 1, 0, 1])
+_Y_MULTICLASS = np.array([0, 1, 2, 0])
+# Binary targets whose two labels are NOT {0, 1}: an offset ({1, 2}) and a
+# signed ({-1, 1}) encoding. type_of_target reports both as "binary", so they
+# clear the multiclass gate and must be rejected by the tighter {0, 1} check.
+_NON_ZERO_ONE_BINARY = [np.array([1, 2, 1, 2]), np.array([-1, 1, -1, 1])]
 _REJECTED_DTYPES = [np.int8, np.int32, np.int64, np.float32, np.float64]
 
 
@@ -40,15 +45,45 @@ def test_lazy_selector_fit_rejects_non_bool_X(Selector, dtype):
 
 @pytest.mark.parametrize("dtype", _REJECTED_DTYPES)
 @pytest.mark.parametrize("Selector", LAZY_SELECTORS)
-def test_lazy_selector_fit_selector_rejects_non_bool_X_test(Selector, dtype):
-    selector = Selector(_HIERARCHY)
+def test_lazy_selector_predict_rejects_non_bool_X(Selector, dtype):
+    selector = Selector(_HIERARCHY).fit(_X_BOOL, _Y)
     with pytest.raises(ValueError, match="bool-dtype"):
-        selector.fit_selector(X_train=_X_BOOL, y_train=_Y, X_test=_X_BOOL.astype(dtype))
+        selector.predict(_X_BOOL.astype(dtype))
 
 
-@pytest.mark.parametrize("dtype", _REJECTED_DTYPES)
+@pytest.mark.parametrize("Selector", EAGER_SELECTORS)
+def test_eager_selector_rejects_non_binary_y(Selector):
+    selector = Selector(_HIERARCHY)
+    with pytest.raises(ValueError, match="binary target"):
+        selector.fit(_X_BOOL, _Y_MULTICLASS)
+
+
 @pytest.mark.parametrize("Selector", LAZY_SELECTORS)
-def test_lazy_selector_fit_selector_rejects_non_bool_X_train(Selector, dtype):
+def test_lazy_selector_rejects_non_binary_y(Selector):
     selector = Selector(_HIERARCHY)
-    with pytest.raises(ValueError, match="bool-dtype"):
-        selector.fit_selector(X_train=_X_BOOL.astype(dtype), y_train=_Y, X_test=_X_BOOL)
+    with pytest.raises(ValueError, match="binary target"):
+        selector.fit(_X_BOOL, _Y_MULTICLASS)
+
+
+@pytest.mark.parametrize("y", _NON_ZERO_ONE_BINARY)
+@pytest.mark.parametrize("Selector", EAGER_SELECTORS)
+def test_eager_selector_rejects_non_zero_one_binary_y(Selector, y):
+    selector = Selector(_HIERARCHY)
+    with pytest.raises(ValueError, match="labelled 0 and 1"):
+        selector.fit(_X_BOOL, y)
+
+
+@pytest.mark.parametrize("y", _NON_ZERO_ONE_BINARY)
+@pytest.mark.parametrize("Selector", LAZY_SELECTORS)
+def test_lazy_selector_rejects_non_zero_one_binary_y(Selector, y):
+    selector = Selector(_HIERARCHY)
+    with pytest.raises(ValueError, match="labelled 0 and 1"):
+        selector.fit(_X_BOOL, y)
+
+
+@pytest.mark.parametrize("Selector", LAZY_SELECTORS)
+def test_lazy_selector_locks_classes_to_zero_one(Selector):
+    # The {0, 1} contract guarantees classes_ == [0, 1] (sorted), so downstream
+    # class-ordered machinery (e.g. predict_proba) can rely on it.
+    selector = Selector(_HIERARCHY).fit(_X_BOOL, _Y)
+    assert np.array_equal(selector.classes_, np.array([0, 1]))

--- a/scihfs/tests/test_eager_base.py
+++ b/scihfs/tests/test_eager_base.py
@@ -18,20 +18,20 @@ def test_abstract_bases_cannot_be_instantiated(abstract_class):
         abstract_class()
 
 
+@pytest.mark.filterwarnings("ignore:Hierarchy consists of multiple")
 @pytest.mark.parametrize(
-    "data, expected_warning",
-    [
-        # X has a column without a corresponding node in the hierarchy.
-        ("wrong_hierarchy_X", "columns in X need to be mapped"),
-        # The hierarchy has nodes without a corresponding column in X.
-        ("wrong_hierarchy_X1", "hierarchy should not include any"),
-    ],
+    "data",
+    ["wrong_hierarchy_X", "wrong_hierarchy_X1"],
+    ids=["column-without-node", "node-without-column"],
 )
-def test_check_hierarchy_X_warns(data, expected_warning, request):
+def test_check_hierarchy_X_raises_on_mismatch(data, request):
+    # A column<->node mismatch is now rejected rather than warned: the eager
+    # (like the lazy) HFS methods are strict consumers of aligned input (only
+    # the HierarchicalPreprocessor tolerates -- and fixes -- a mismatch).
     X, hierarchy, columns = request.getfixturevalue(data)
     y = np.zeros(X.shape[0], dtype=int)
     selector = _MinimalEagerSelector(hierarchy)
-    with pytest.warns(UserWarning, match=expected_warning):
+    with pytest.raises(ValueError, match="not aligned"):
         selector.fit(X, y, columns=columns)
 
 

--- a/scihfs/tests/test_feature_selection_filter.py
+++ b/scihfs/tests/test_feature_selection_filter.py
@@ -1,172 +1,226 @@
+"""Behaviour tests for the lazy hierarchical feature-selection classifiers.
+
+The golden masks and predictions below were captured from the pre-reshape
+implementation on the real fit + predict path (no post-fit monkeypatching), so
+they pin the algorithms' behaviour across the lazy-classifier redesign. The
+``lazy_data2`` fixture carries real (non-degenerate) training data, so every
+algorithm's relevance / MST branches are actually exercised there.
+"""
+
+import copy
+
 import networkx as nx
 import numpy as np
 import pytest
+from sklearn.exceptions import NotFittedError
+from sklearn.naive_bayes import BernoulliNB
 
-from scihfs.selectors.hip import HIP
-from scihfs.selectors.hnb import HNB
-from scihfs.selectors.hnbs import HNBs
-from scihfs.selectors.mr import MR
-from scihfs.selectors.rnb import RNB
-from scihfs.selectors.tan import TAN
+from scihfs.metrics import mean_selected_fraction, sensitivity_specificity_product
+from scihfs.selectors import HIP, HNB, MR, RNB, TAN, HieAODE, HNBs
+
+# ---------------------------------------------------------------------------
+# Golden masks + predictions on lazy_data2 (real training data).
+# ---------------------------------------------------------------------------
+
+_LAZY_DATA2_CASES = [
+    (lambda h: HIP(h), [[0, 1, 1, 1], [0, 0, 1, 1]], [0, 1]),
+    (lambda h: HNB(hierarchy=h, k=2), [[0, 1, 1, 0], [0, 0, 1, 1]], [0, 1]),
+    (lambda h: HNBs(hierarchy=h), [[0, 1, 1, 1], [0, 0, 1, 1]], [0, 1]),
+    (lambda h: RNB(hierarchy=h, k=2), [[0, 1, 1, 0], [0, 1, 1, 0]], [0, 1]),
+    (lambda h: MR(h), [[0, 1, 1, 1], [0, 0, 1, 1]], [0, 1]),
+    (lambda h: TAN(h), [[1, 1, 1, 1], [1, 1, 0, 0]], [0, 1]),
+]
 
 
-@pytest.fixture
-def data1():
-    edges = [
-        (9, 3),
-        (9, 7),
-        (7, 1),
-        (3, 1),
-        (7, 6),
-        (1, 6),
-        (1, 5),
-        (6, 8),
-        (3, 0),
-        (4, 0),
-        (1, 5),
-        (2, 0),
-        (10, 2),
-        (4, 11),
-        (5, 11),
-    ]
-    hierarchy = nx.DiGraph(edges)
-    X_train = np.ones((2, len(hierarchy.nodes)))
-    y_train = np.array([0, 1])
-    X_test = np.array(
-        [[1, 0, 1, 1, 0, 0, 0, 1, 0, 1, 1, 0], [1, 0, 1, 1, 0, 0, 0, 1, 0, 1, 1, 0]]
+@pytest.mark.parametrize(
+    "factory, exp_masks, exp_pred",
+    _LAZY_DATA2_CASES,
+    ids=["HIP", "HNB", "HNBs", "RNB", "MR", "TAN"],
+)
+def test_lazy_selectors_data2(lazy_data2, factory, exp_masks, exp_pred):
+    small_DAG, X_train, y_train, X_test, _ = lazy_data2
+    selector = factory(small_DAG)
+    assert selector.fit(X_train, y_train) is selector
+
+    masks = selector.select(X_test)
+    assert masks.dtype == bool
+    assert masks.shape == (X_test.shape[0], X_train.shape[1])
+    assert np.array_equal(masks.astype(int), np.array(exp_masks))
+
+    preds = selector.predict(X_test)
+    assert np.array_equal(preds, np.array(exp_pred))
+
+
+@pytest.mark.filterwarnings("ignore:Hierarchy consists of multiple")
+@pytest.mark.parametrize(
+    "factory", [lambda h: HIP(h), lambda h: MR(h)], ids=["HIP", "MR"]
+)
+def test_lazy_selectors_data1(lazy_data1, factory):
+    hierarchy, X_train, y_train, X_test, _, _ = lazy_data1
+    selector = factory(nx.to_numpy_array(hierarchy)).fit(X_train, y_train)
+
+    exp_masks = [[0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0]] * 2
+    assert np.array_equal(selector.select(X_test).astype(int), np.array(exp_masks))
+    assert np.array_equal(selector.predict(X_test), np.array([0, 0]))
+
+
+@pytest.mark.filterwarnings("ignore:Hierarchy consists of multiple")
+def test_TAN_data3(lazy_data3):
+    hierarchy, X_train_ones, _, y_train, X_test, _, _ = lazy_data3
+    selector = TAN(nx.to_numpy_array(hierarchy)).fit(X_train_ones, y_train)
+
+    exp_masks = [[1, 1, 0, 1, 1, 0]] * 2
+    assert np.array_equal(selector.select(X_test).astype(int), np.array(exp_masks))
+    assert np.array_equal(selector.predict(X_test), np.array([0, 0]))
+
+
+# ---------------------------------------------------------------------------
+# Regression: a non-identity columns= mapping must be honoured.
+#
+# fit() relabels the hierarchy nodes to their data-column indices, so the
+# per-instance status dicts are already keyed by column index. select() and
+# _predict_instance() must therefore use the node directly; mapping it a second
+# time through _column_index() (the former bug) is a no-op only when columns is
+# the identity, so it went unnoticed. Here the data columns are permuted and a
+# matching columns= mapping is supplied, so old feature k stays tied to node k
+# but sits in a different column. Correct output is then equivariant under that
+# permutation; the double-map is not.
+#
+# TAN is deliberately excluded: its MST tie-breaking (np.argsort over the CMI
+# matrix) is itself column-order dependent, so equal-CMI edges make its output
+# non-equivariant regardless of this bug. It shares the same (fixed) select /
+# _predict_instance as the others, so nothing about the fix goes uncovered.
+# ---------------------------------------------------------------------------
+
+_PERM_FACTORIES = [
+    lambda h: HIP(h),
+    lambda h: HNB(hierarchy=h, k=2),
+    lambda h: HNBs(hierarchy=h),
+    lambda h: RNB(hierarchy=h, k=2),
+    lambda h: MR(h),
+]
+
+
+@pytest.mark.parametrize(
+    "factory", _PERM_FACTORIES, ids=["HIP", "HNB", "HNBs", "RNB", "MR"]
+)
+def test_lazy_selectors_honour_non_identity_columns(lazy_data2, factory):
+    small_DAG, X_train, y_train, X_test, _ = lazy_data2
+    # new column j holds old column perm[j], remapped back onto node perm[j].
+    perm = [2, 0, 3, 1]
+
+    base = factory(small_DAG).fit(X_train, y_train)  # identity columns
+    permuted = factory(small_DAG).fit(X_train[:, perm], y_train, columns=perm)
+
+    # predictions are per-instance labels -> unchanged by column reordering.
+    assert np.array_equal(permuted.predict(X_test[:, perm]), base.predict(X_test))
+    # masks follow the same permutation of the feature axis.
+    assert np.array_equal(permuted.select(X_test[:, perm]), base.select(X_test)[:, perm])
+
+
+# ---------------------------------------------------------------------------
+# Estimator contract: fitted-gating and prediction purity.
+# ---------------------------------------------------------------------------
+
+
+def test_predict_and_select_require_fit(lazy_data2):
+    small_DAG, _, _, X_test, _ = lazy_data2
+    selector = HIP(small_DAG)
+    with pytest.raises(NotFittedError):
+        selector.predict(X_test)
+    with pytest.raises(NotFittedError):
+        selector.select(X_test)
+
+
+def test_predict_and_select_are_pure(lazy_data2):
+    # predict/select must not mutate the fitted estimator's __dict__.
+    small_DAG, X_train, y_train, X_test, _ = lazy_data2
+    selector = HNB(hierarchy=small_DAG, k=2).fit(X_train, y_train)
+    before = copy.copy(selector.__dict__)
+
+    selector.predict(X_test)
+    selector.predict(X_test, return_masks=True)
+    selector.select(X_test)
+
+    assert selector.__dict__.keys() == before.keys()
+    for key in before:
+        assert selector.__dict__[key] is before[key]
+
+
+def test_masked_nb_matches_bernoullinb_and_empty_is_majority(lazy_data2):
+    # The one-shot masked NB must (a) reproduce a stock BernoulliNB's class
+    # probabilities when every column is selected -- the equivalence that keeps
+    # the golden predictions unchanged after dropping the fit-a-clone-per-instance
+    # loop -- and (b) fall back to the training majority class on an empty
+    # selection, since with no evidence the joint log-likelihood reduces to the
+    # class log-prior.
+    small_DAG, X_train, y_train, X_test, _ = lazy_data2
+    selector = HIP(small_DAG).fit(X_train, y_train)
+    reference = BernoulliNB().fit(X_train, y_train)
+    all_columns = list(range(X_train.shape[1]))
+    majority = np.bincount(y_train).argmax()
+
+    for row in X_test:
+        masked = selector._nb.predict_proba_masked(row, all_columns)
+        assert np.allclose(masked, reference.predict_proba(row.reshape(1, -1))[0])
+        empty = selector._nb.predict_proba_masked(row, [])
+        assert selector._nb.classes_[np.argmax(empty)] == majority
+
+
+def test_predict_proba_normalized_and_consistent_with_predict(lazy_data2):
+    # predict_proba is the primitive: each row is a proper distribution over
+    # classes_, and predict is exactly its per-instance argmax.
+    small_DAG, X_train, y_train, X_test, _ = lazy_data2
+    selector = HNB(hierarchy=small_DAG, k=2).fit(X_train, y_train)
+    proba = selector.predict_proba(X_test)
+
+    assert proba.shape == (X_test.shape[0], selector.classes_.shape[0])
+    assert np.all((proba >= 0) & (proba <= 1))
+    assert np.allclose(proba.sum(axis=1), 1.0)
+    assert np.array_equal(
+        selector.classes_[np.argmax(proba, axis=1)], selector.predict(X_test)
     )
-    relevance = [0.25, 0.23, 0.38, 0.25, 0.28, 0.38, 0.26, 0.31, 0.26, 0.23, 0.21, 0.26]
-
-    return (
-        hierarchy,
-        X_train,
-        y_train,
-        X_test,
-        relevance,
-    )
 
 
-@pytest.fixture
-def data2():
-    edges = [(4, 0), (0, 3), (2, 3), (5, 2), (5, 1)]
-    hierarchy = nx.DiGraph(edges)
-    X_train_ones = np.ones((9, len(hierarchy.nodes)))
-    X_train = np.array(
-        [
-            [1, 1, 1, 1, 1, 1],
-            [0, 1, 0, 0, 1, 1],
-            [1, 1, 0, 0, 1, 1],
-            [0, 1, 1, 0, 1, 1],
-            [0, 0, 1, 0, 1, 1],
-            [0, 0, 0, 0, 0, 1],
-            [0, 0, 1, 1, 0, 1],
-            [1, 0, 0, 1, 1, 0],
-            [0, 1, 0, 0, 0, 1],
-        ]
-    )
-    y_train = np.array([0, 1, 1, 0, 1, 1, 0, 1, 1])
-    X_test = np.array([[0, 0, 1, 0, 1, 1], [0, 1, 1, 0, 1, 1]])
-    resulted_features = np.array(
-        [[0.0, 1.0, 1.0, 1.0, 1.0, 0.0], [0.0, 1.0, 1.0, 1.0, 1.0, 0.0]]
-    )
-    return (hierarchy, X_train_ones, X_train, y_train, X_test, resulted_features)
+def test_predict_return_masks_matches_predict_and_select(lazy_data2):
+    # predict(return_masks=True) yields both outputs from one sweep: the
+    # predictions match plain predict and the masks match select exactly.
+    small_DAG, X_train, y_train, X_test, _ = lazy_data2
+    selector = HNB(hierarchy=small_DAG, k=2).fit(X_train, y_train)
+
+    preds, masks = selector.predict(X_test, return_masks=True)
+    assert np.array_equal(preds, selector.predict(X_test))
+    assert masks.dtype == bool
+    assert np.array_equal(masks, selector.select(X_test))
+
+    # The default stays single-output (backward compatible).
+    plain = selector.predict(X_test)
+    assert isinstance(plain, np.ndarray)
 
 
-# Test feature selection of HNB
-def test_HNB(lazy_data2):
-    small_DAG, train_x_data, train_y_data, test_x_data, test_y_data = lazy_data2
-    selector = HNB(hierarchy=small_DAG, k=2)
-    selector.fit_selector(X_train=train_x_data, y_train=train_y_data, X_test=test_x_data)
-    pred = selector.select_and_predict(predict=True, saveFeatures=True)
-    assert np.array_equal(selector.get_features(), np.array([[0, 1, 1, 0], [0, 0, 1, 1]]))
-    assert np.array_equal(pred, np.array([0, 1]))
-    assert selector.get_score(test_y_data, pred)["accuracy"] == 0.0  # accuracy
-    assert selector.get_score(test_y_data, pred)["1"]["recall"] == 0.0  # sensitivity
-    assert selector.get_score(test_y_data, pred)["0"]["recall"] == 0.0  # specivity
-    assert selector.get_score(test_y_data, pred)["sensitivityxspecificity"] == 0.0
+def test_hie_aode_disables_predict_proba(lazy_data2):
+    # HieAODE overrides predict with AODE-style aggregation, so the inherited
+    # naive-Bayes predict_proba would be silently inconsistent -- it is disabled.
+    small_DAG, X_train, y_train, X_test, _ = lazy_data2
+    selector = HieAODE(small_DAG).fit(X_train, y_train)
+    with pytest.raises(AttributeError):
+        selector.predict_proba(X_test)
 
 
-# Test feature selection of HNBs
-def test_HNBs(lazy_data2):
-    small_DAG, train_x_data, train_y_data, test_x_data, test_y_data = lazy_data2
-    selector = HNBs(hierarchy=small_DAG)
-    selector.fit_selector(X_train=train_x_data, y_train=train_y_data, X_test=test_x_data)
-    pred = selector.select_and_predict(predict=True, saveFeatures=True)
-    assert np.array_equal(pred, np.array([0, 1]))
-    assert np.array_equal(selector.get_features(), np.array([[0, 1, 1, 1], [0, 0, 1, 1]]))
-    assert selector.get_score(test_y_data, pred)["accuracy"] == 0.0  # accuracy
-    assert selector.get_score(test_y_data, pred)["1"]["recall"] == 0.0  # sensitivity
-    assert selector.get_score(test_y_data, pred)["0"]["recall"] == 0.0  # specivity
-    assert selector.get_score(test_y_data, pred)["sensitivityxspecificity"] == 0.0
+# ---------------------------------------------------------------------------
+# Metrics helpers (former get_score internals, now in scihfs.metrics).
+# ---------------------------------------------------------------------------
 
 
-# Test feature selection of RNB
-def test_RNB(lazy_data2):
-    small_DAG, train_x_data, train_y_data, test_x_data, test_y_data = lazy_data2
-    selector = RNB(hierarchy=small_DAG, k=2)
-    selector.fit_selector(X_train=train_x_data, y_train=train_y_data, X_test=test_x_data)
-    pred = selector.select_and_predict(predict=True, saveFeatures=True)
-    assert np.array_equal(pred, np.array([0, 1]))
-    assert np.array_equal(selector.get_features(), np.array([[0, 1, 1, 0], [0, 1, 1, 0]]))
+def test_lazy_metrics(lazy_data2):
+    small_DAG, X_train, y_train, X_test, y_test = lazy_data2
+    selector = HNB(hierarchy=small_DAG, k=2).fit(X_train, y_train)
+    preds = selector.predict(X_test)
+    masks = selector.select(X_test)
 
-
-# Test feature selection of MR
-def test_MR(lazy_data1):
-    hierarchy, X_train, y_train, X_test, y_test, relevance = lazy_data1
-    selector = MR(nx.to_numpy_array(hierarchy))
-    selector.fit_selector(X_train=X_train, y_train=y_train, X_test=X_test)
-    selector._relevance = relevance
-    selector._hierarchy_graph = hierarchy
-    pred = selector.select_and_predict(predict=True, saveFeatures=True)
-    features = selector.get_features()
-    result_features = np.array(
-        [[0, 0, 1, 0, 1, 1, 1, 1, 0, 0, 0, 0], [0, 0, 1, 0, 1, 1, 1, 1, 0, 0, 0, 0]]
-    )
-    assert features.all() == result_features.all()
-    assert selector.get_score(y_test, pred)["accuracy"] == 0.5  # accuracy
-    assert selector.get_score(y_test, pred)["1"]["recall"] == 0.0  # sensitivity
-    assert selector.get_score(y_test, pred)["0"]["recall"] == 1.0  # specivity
-    assert selector.get_score(y_test, pred)["sensitivityxspecificity"] == 0.0
-
-
-# Test feature selection of HIP
-def test_HIP(lazy_data1):
-    hierarchy, X_train, y_train, X_test, y_test, relevance = lazy_data1
-    selector = HIP(nx.to_numpy_array(hierarchy))
-    selector.fit_selector(X_train=X_train, y_train=y_train, X_test=X_test)
-    selector._relevance = relevance
-    selector._hierarchy_graph = hierarchy
-    pred = selector.select_and_predict(predict=True, saveFeatures=True)
-    features = selector.get_features()
-    result_features = np.array(
-        [[1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0], [1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0]]
-    )
-    assert features.all() == result_features.all()
-    assert selector.get_score(y_test, pred)["accuracy"] == 0.5  # accuracy
-    assert selector.get_score(y_test, pred)["1"]["recall"] == 0.0  # sensitivity
-    assert selector.get_score(y_test, pred)["0"]["recall"] == 1.0  # specivity
-    assert selector.get_score(y_test, pred)["sensitivityxspecificity"] == 0.0
-
-
-def test_TAN(lazy_data3):
-    (
-        hierarchy,
-        X_train_ones,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        resulted_features,
-    ) = lazy_data3
-    selector = TAN(nx.to_numpy_array(hierarchy))
-    selector.fit_selector(X_train=X_train_ones, y_train=y_train, X_test=X_test)
-    selector._xtrain = X_train
-    selector._hierarchy_graph = hierarchy
-    selector.select_and_predict(predict=True, saveFeatures=True)
-    f = selector.get_features()
-    assert resulted_features.all() == f.all()
-    pred = selector.select_and_predict(predict=True, saveFeatures=True)
-    assert selector.get_score(y_test, pred)["accuracy"] == 0.5  # accuracy
-    assert selector.get_score(y_test, pred)["1"]["recall"] == 1.0  # sensitivity
-    assert selector.get_score(y_test, pred)["0"]["recall"] == 0.0  # specivity
-    assert selector.get_score(y_test, pred)["sensitivityxspecificity"] == 0.0
+    # y_test = [1, 0], preds = [0, 1] -> both recalls 0 -> product 0.
+    assert sensitivity_specificity_product(y_test, preds) == 0.0
+    # masks [[0,1,1,0],[0,0,1,1]] -> 4 selected of 8 cells.
+    assert mean_selected_fraction(masks) == 0.5
+    # ClassifierMixin.score gives accuracy for free.
+    assert selector.score(X_test, y_test) == 0.0

--- a/scihfs/tests/test_feature_selection_filter.py
+++ b/scihfs/tests/test_feature_selection_filter.py
@@ -12,6 +12,7 @@ import copy
 import networkx as nx
 import numpy as np
 import pytest
+import scipy.sparse as sp
 from sklearn.exceptions import NotFittedError
 from sklearn.naive_bayes import BernoulliNB
 
@@ -116,6 +117,34 @@ def test_lazy_selectors_honour_non_identity_columns(lazy_data2, factory):
     assert np.array_equal(permuted.predict(X_test[:, perm]), base.predict(X_test))
     # masks follow the same permutation of the feature axis.
     assert np.array_equal(permuted.select(X_test[:, perm]), base.select(X_test)[:, perm])
+
+
+# ---------------------------------------------------------------------------
+# Sparse (CSR-bool) input must match dense input exactly.
+#
+# The lazy classifiers accept scipy.sparse at the validate_data boundary and
+# densify internally, so fitting and predicting on a CSR-bool copy of the data
+# must reproduce the dense predict / select exactly (same fit, same per-instance
+# selection, same scoring). Both CSR containers (array and matrix) are covered.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sparse_type", [sp.csr_array, sp.csr_matrix], ids=["csr_array", "csr_matrix"]
+)
+@pytest.mark.parametrize(
+    "factory",
+    [case[0] for case in _LAZY_DATA2_CASES],
+    ids=["HIP", "HNB", "HNBs", "RNB", "MR", "TAN"],
+)
+def test_lazy_selectors_accept_sparse_like_dense(lazy_data2, factory, sparse_type):
+    small_DAG, X_train, y_train, X_test, _ = lazy_data2
+
+    dense = factory(small_DAG).fit(X_train, y_train)
+    sparse_fit = factory(small_DAG).fit(sparse_type(X_train), y_train)
+
+    assert np.array_equal(sparse_fit.predict(sparse_type(X_test)), dense.predict(X_test))
+    assert np.array_equal(sparse_fit.select(sparse_type(X_test)), dense.select(X_test))
 
 
 # ---------------------------------------------------------------------------

--- a/scihfs/tests/test_feature_selection_filter.py
+++ b/scihfs/tests/test_feature_selection_filter.py
@@ -227,6 +227,31 @@ def test_lazy_dataframe_with_adjacency_hierarchy_raises():
 
 
 # ---------------------------------------------------------------------------
+# The hierarchy nodes and the data columns must be in bijection.
+#
+# The lazy classifiers work on a column-keyed graph (each node is a data
+# column), so a hierarchy node with no column -- or a column with no node --
+# is rejected up front rather than silently mis-indexed. (The preprocessor is
+# the one estimator that tolerates and fixes such a mismatch instead.)
+# ---------------------------------------------------------------------------
+
+
+def test_lazy_selector_rejects_hierarchy_column_mismatch():
+    X = np.array([[1, 1, 0, 1], [1, 0, 0, 0]], dtype=bool)  # 4 columns
+    y = np.array([0, 1])
+
+    # More nodes than columns: node 4 has no data column.
+    too_many_nodes = nx.to_numpy_array(nx.DiGraph([(0, 1), (1, 2), (2, 3), (3, 4)]))
+    with pytest.raises(ValueError, match="not aligned"):
+        HIP(too_many_nodes).fit(X, y)
+
+    # More columns than nodes: column 3 has no hierarchy node.
+    too_few_nodes = nx.to_numpy_array(nx.DiGraph([(0, 1), (1, 2)]))
+    with pytest.raises(ValueError, match="not aligned"):
+        HIP(too_few_nodes).fit(X, y)
+
+
+# ---------------------------------------------------------------------------
 # Estimator contract: fitted-gating and prediction purity.
 # ---------------------------------------------------------------------------
 

--- a/scihfs/tests/test_feature_selection_filter.py
+++ b/scihfs/tests/test_feature_selection_filter.py
@@ -11,6 +11,7 @@ import copy
 
 import networkx as nx
 import numpy as np
+import pandas as pd
 import pytest
 import scipy.sparse as sp
 from sklearn.exceptions import NotFittedError
@@ -145,6 +146,84 @@ def test_lazy_selectors_accept_sparse_like_dense(lazy_data2, factory, sparse_typ
 
     assert np.array_equal(sparse_fit.predict(sparse_type(X_test)), dense.predict(X_test))
     assert np.array_equal(sparse_fit.select(sparse_type(X_test)), dense.select(X_test))
+
+
+# ---------------------------------------------------------------------------
+# DataFrame input: the column->node mapping is auto-derived from feature names.
+#
+# The lazy classifiers inherit HierarchyMixin's auto-derive plumbing: a
+# DataFrame X + a named DiGraph + columns=None maps each feature name to its
+# node (see _auto_derive_columns), so passing a DataFrame is exactly equivalent
+# to passing the same array with the derived columns= mapping. The frame below
+# lists its columns in shuffled order so a positional mapping would be wrong.
+# ---------------------------------------------------------------------------
+
+
+def _named_graph():
+    return nx.DiGraph([("A", "B"), ("B", "C"), ("A", "D")])
+
+
+def _named_dataframe():
+    return pd.DataFrame(
+        {
+            "C": [1, 0, 0, 1],
+            "A": [1, 1, 0, 1],
+            "D": [0, 1, 0, 0],
+            "B": [1, 0, 0, 1],
+        }
+    ).astype(bool)
+
+
+_DF_Y = np.array([1, 0, 0, 1])
+
+
+def test_lazy_autoderives_columns_from_dataframe():
+    # Nodes A=0, B=1, C=2, D=3; frame columns C, A, D, B -> mapping [2, 0, 3, 1].
+    selector = HIP(_named_graph()).fit(_named_dataframe(), _DF_Y)
+    assert selector.get_columns() == [2, 0, 3, 1]
+
+
+def test_lazy_ndarray_keeps_positional_mapping():
+    # A plain ndarray has no feature names, so the mapping stays positional.
+    X = _named_dataframe().to_numpy()
+    selector = HIP(_named_graph()).fit(X, _DF_Y)
+    assert not hasattr(selector, "feature_names_in_")
+    assert selector.get_columns() == [0, 1, 2, 3]
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [case[0] for case in _LAZY_DATA2_CASES],
+    ids=["HIP", "HNB", "HNBs", "RNB", "MR", "TAN"],
+)
+def test_lazy_dataframe_matches_explicit_columns(factory):
+    # DataFrame input must be identical to the same array fed with the
+    # auto-derived columns= mapping -- predict, select and the mapping itself.
+    df = _named_dataframe()
+    derived = [2, 0, 3, 1]
+
+    df_fit = factory(_named_graph()).fit(df, _DF_Y)
+    col_fit = factory(_named_graph()).fit(df.to_numpy(), _DF_Y, columns=derived)
+
+    assert df_fit.get_columns() == derived
+    assert np.array_equal(df_fit.predict(df), col_fit.predict(df.to_numpy()))
+    assert np.array_equal(df_fit.select(df), col_fit.select(df.to_numpy()))
+
+
+def test_lazy_orphan_dataframe_column_raises():
+    # A DataFrame column with no matching node is rejected (selectors cannot
+    # extend the hierarchy, unlike the HierarchicalPreprocessor).
+    df = _named_dataframe()
+    df["unicorn"] = [False, True, False, False]
+    with pytest.raises(ValueError, match="no matching node"):
+        HIP(_named_graph()).fit(df, _DF_Y)
+
+
+def test_lazy_dataframe_with_adjacency_hierarchy_raises():
+    # An adjacency-matrix hierarchy has no node names to match feature names.
+    hierarchy = nx.to_numpy_array(_named_graph())
+    with pytest.raises(ValueError, match="Cannot auto-derive columns"):
+        HIP(hierarchy).fit(_named_dataframe(), _DF_Y)
 
 
 # ---------------------------------------------------------------------------

--- a/scihfs/tests/test_feature_selection_filter.py
+++ b/scihfs/tests/test_feature_selection_filter.py
@@ -71,7 +71,11 @@ def test_TAN_data3(lazy_data3):
     hierarchy, X_train_ones, _, y_train, X_test, _, _ = lazy_data3
     selector = TAN(nx.to_numpy_array(hierarchy)).fit(X_train_ones, y_train)
 
-    exp_masks = [[1, 1, 0, 1, 1, 0]] * 2
+    # X_train_ones is constant, so every pairwise CMI is exactly 0 and MST
+    # edge order is decided entirely by tie-breaking. _build_mst() now sorts
+    # with kind="stable", so ties resolve by flat (node1, node2) index on
+    # every platform; these golden masks were captured under that rule.
+    exp_masks = [[1, 1, 1, 1, 0, 1], [1, 1, 0, 1, 1, 0]]
     assert np.array_equal(selector.select(X_test).astype(int), np.array(exp_masks))
     assert np.array_equal(selector.predict(X_test), np.array([0, 0]))
 

--- a/scihfs/tests/test_helpers.py
+++ b/scihfs/tests/test_helpers.py
@@ -9,7 +9,6 @@ from scipy.stats import entropy
 
 from scihfs.helpers import (
     add_virtual_root_node,
-    check_data,
     compute_aggregated_values,
     get_relevance,
     shrink_dag,
@@ -136,17 +135,6 @@ def test_gain_ratio(data2):
     # cross-check. The two implementations agree only to floating-point noise.
     gr_expected = [_reference_information_gain_ratio(X[:, i], y) for i in range(len(X))]
     assert gr == pytest.approx(gr_expected)
-
-
-def test_check_data_raises_on_propagation_violation():
-    # Edge (0, 1) requires that whenever the child (column 1) is 1, the parent
-    # (column 0) is 1 too. Instance 0 has parent 0 but child 1, violating it.
-    dag = nx.DiGraph()
-    dag.add_edge(0, 1)
-    x_data = np.array([[0, 1]])
-    y_data = np.array([0])
-    with pytest.raises(ValueError, match="0-1-propagation"):
-        check_data(dag, x_data, y_data)
 
 
 def test_information_gain_skips_empty_sparse_column():

--- a/scihfs/tests/test_hie_aode.py
+++ b/scihfs/tests/test_hie_aode.py
@@ -12,14 +12,14 @@ from scihfs.selectors import HieAODE
 def test_hie_aode(lazy_data2):
     small_DAG, train_x_data, train_y_data, test_x_data, _ = lazy_data2
     selector = HieAODE(hierarchy=small_DAG)
-    selector.fit_selector(X_train=train_x_data, y_train=train_y_data, X_test=test_x_data)
-    _ = selector.select_and_predict(predict=True, saveFeatures=True)
+    selector.fit(train_x_data, train_y_data)
+    _ = selector.predict(test_x_data)
 
 
 def test_calculate_dependency_ascendant_class(lazy_data2):
-    small_DAG, train_x_data, train_y_data, test_x_data, _ = lazy_data2
+    small_DAG, train_x_data, train_y_data, _, _ = lazy_data2
     selector = HieAODE(hierarchy=small_DAG)
-    selector.fit_selector(X_train=train_x_data, y_train=train_y_data, X_test=test_x_data)
+    selector.fit(train_x_data, train_y_data)
     feature_idx = 2
     expected = np.full((selector.n_features_in_, selector.n_classes_, 2), -1)
     expected[0][0][0] = 0.0

--- a/scihfs/tests/test_sklearn_conformance.py
+++ b/scihfs/tests/test_sklearn_conformance.py
@@ -92,6 +92,9 @@ _COMMON_BOOL_XFAILS = (
     "check_dict_unchanged",
     "check_dont_overwrite_parameters",
     "check_dtype_object",
+    "check_estimator_sparse_array",
+    "check_estimator_sparse_matrix",
+    "check_estimator_sparse_tag",
     "check_estimators_dtypes",
     "check_estimators_fit_returns_self",
     "check_estimators_nan_inf",
@@ -115,9 +118,6 @@ _COMMON_BOOL_XFAILS = (
 
 
 _TRANSFORMER_BOOL_XFAILS = (
-    "check_estimator_sparse_array",
-    "check_estimator_sparse_matrix",
-    "check_estimator_sparse_tag",
     "check_transformer_data_not_an_array",
     "check_transformer_general",
     "check_transformer_preserve_dtypes",
@@ -633,13 +633,14 @@ _SECTION_A_CHECKS = [
 def _check_estimator_sparse_container(name, estimator_orig, sparse_type):
     """Mirror sklearn's sparse-container check on bool data.
 
-    The eager transformers declare input_tags.sparse=True and validate with
-    accept_sparse, so fitting sparse *bool* input must succeed (sklearn's check
-    feeds sparse float, which the contract rejects -- see
-    check_estimator_sparse_array in _EXPECTED_FAILED_CHECKS).
-    Currently, the lazy classifiers are dense-only (sparse tag False); their
-    sparse handling is covered by check_estimator_sparse_tag instead,
-    so they are skipped here.
+    Both the eager transformers and the lazy classifiers declare
+    input_tags.sparse=True and validate with accept_sparse, so fitting sparse
+    *bool* input must succeed -- the eager path keeps it sparse, the lazy path
+    densifies internally (for now, might change in the future).
+    (sklearn's own check feeds sparse *float*, which the bool-dtype contract
+    rejects -- see check_estimator_sparse_array in the expected-failure sets.)
+    The early return keeps the branch faithful to sklearn for any hypothetical
+    sparse=False estimator, though no scihfs estimator declares that.
     """
     if not get_tags(estimator_orig).input_tags.sparse:
         return

--- a/scihfs/tests/test_sklearn_conformance.py
+++ b/scihfs/tests/test_sklearn_conformance.py
@@ -43,7 +43,7 @@ import networkx as nx
 import numpy as np
 import pytest
 import scipy.sparse as sparse
-from sklearn.base import clone
+from sklearn.base import clone, is_classifier
 from sklearn.exceptions import NotFittedError
 from sklearn.model_selection import ShuffleSplit
 from sklearn.pipeline import make_pipeline
@@ -81,54 +81,71 @@ _BOOL_DTYPE_XFAIL_REASON = (
 
 # The exact set of check_estimator checks that fail because scihfs enforces
 # bool-dtype input. Declaring them here (instead of strict-xfailing the whole
-# row) lets the ~17 dtype-independent conformance checks actually run and pass,
+# row) lets the dtype-independent conformance checks actually run and pass,
 # while these are recorded as expected failures. With on_fail='raise' (the
 # default), any NEW failure outside this set fails the test as a real regression.
 #
-# All estimators in ALL_ESTIMATORS share this identical set.
-_EXPECTED_FAILED_CHECKS = {
-    name: _BOOL_DTYPE_XFAIL_REASON
-    for name in (
-        "check_dict_unchanged",
-        "check_dont_overwrite_parameters",
-        "check_dtype_object",
-        "check_estimator_sparse_array",
-        "check_estimator_sparse_matrix",
-        "check_estimator_sparse_tag",
-        "check_estimators_dtypes",
-        "check_estimators_fit_returns_self",
-        "check_estimators_nan_inf",
-        "check_estimators_overwrite_params",
-        "check_estimators_pickle",
-        "check_f_contiguous_array_estimator",
-        "check_fit2d_1feature",
-        "check_fit2d_1sample",
-        "check_fit2d_predict1d",
-        "check_fit_check_is_fitted",
-        "check_fit_idempotent",
-        "check_fit_score_takes_y",
-        "check_methods_sample_order_invariance",
-        "check_methods_subset_invariance",
-        "check_n_features_in",
-        "check_n_features_in_after_fitting",
-        "check_pipeline_consistency",
-        "check_positive_only_tag_during_fit",
-        "check_readonly_memmap_input",
-        "check_transformer_data_not_an_array",
-        "check_transformer_general",
-        "check_transformer_preserve_dtypes",
+# sklearn runs a role-specific subset of checks, so the expected failures are
+# split accordingly: a shared core, plus the transformer-only checks (eager
+# selectors + preprocessor) or the classifier-only checks (lazy selectors).
+_COMMON_BOOL_XFAILS = (
+    "check_dict_unchanged",
+    "check_dont_overwrite_parameters",
+    "check_dtype_object",
+    "check_estimators_dtypes",
+    "check_estimators_fit_returns_self",
+    "check_estimators_nan_inf",
+    "check_estimators_overwrite_params",
+    "check_estimators_pickle",
+    "check_f_contiguous_array_estimator",
+    "check_fit2d_1feature",
+    "check_fit2d_1sample",
+    "check_fit2d_predict1d",
+    "check_fit_check_is_fitted",
+    "check_fit_idempotent",
+    "check_fit_score_takes_y",
+    "check_methods_sample_order_invariance",
+    "check_methods_subset_invariance",
+    "check_n_features_in",
+    "check_n_features_in_after_fitting",
+    "check_pipeline_consistency",
+    "check_positive_only_tag_during_fit",
+    "check_readonly_memmap_input",
+)
+
+
+_TRANSFORMER_BOOL_XFAILS = (
+    "check_estimator_sparse_array",
+    "check_estimator_sparse_matrix",
+    "check_estimator_sparse_tag",
+    "check_transformer_data_not_an_array",
+    "check_transformer_general",
+    "check_transformer_preserve_dtypes",
+)
+
+
+_CLASSIFIER_BOOL_XFAILS = (
+    "check_classifier_data_not_an_array",
+    "check_classifiers_classes",
+    "check_classifiers_one_label",
+    "check_classifiers_train",
+    "check_supervised_y_2d",
+)
+
+
+def _expected_failed_checks(estimator):
+    role_xfails = (
+        _CLASSIFIER_BOOL_XFAILS if is_classifier(estimator) else _TRANSFORMER_BOOL_XFAILS
     )
-}
+    return {name: _BOOL_DTYPE_XFAIL_REASON for name in _COMMON_BOOL_XFAILS + role_xfails}
 
 
 @pytest.mark.parametrize("estimator", ALL_ESTIMATORS)
 def test_all_estimators(estimator):
     hierarchy_graph = nx.DiGraph()
     adj_matrix = nx.to_numpy_array(hierarchy_graph)
-    check_estimator(
-        estimator(adj_matrix),
-        expected_failed_checks=_EXPECTED_FAILED_CHECKS,
-    )
+    est = estimator(adj_matrix)
+    check_estimator(est, expected_failed_checks=_expected_failed_checks(est))
 
 
 # ---------------------------------------------------------------------------
@@ -555,7 +572,9 @@ def check_pipeline_consistency(name, estimator_orig):
 
 def check_transformer_data_not_an_array(name, transformer_orig):
     # The transformer behaves the same when X is not an ndarray (a _NotAnArray
-    # wrapper, or a plain list).
+    # wrapper, or a plain list). Classifier-only estimators have no transform.
+    if not hasattr(transformer_orig, "transform"):
+        return
     X, y = _binary_Xy(n_samples=30)
     X = _enforce_estimator_tags_X(transformer_orig, X)
     _check_transformer_binary(
@@ -614,11 +633,16 @@ _SECTION_A_CHECKS = [
 def _check_estimator_sparse_container(name, estimator_orig, sparse_type):
     """Mirror sklearn's sparse-container check on bool data.
 
-    scihfs declares input_tags.sparse=True and validates with accept_sparse,
-    so fitting sparse *bool* input must succeed (sklearn's check feeds sparse
-    float, which the contract rejects -- see check_estimator_sparse_array in
-    _EXPECTED_FAILED_CHECKS).
+    The eager transformers declare input_tags.sparse=True and validate with
+    accept_sparse, so fitting sparse *bool* input must succeed (sklearn's check
+    feeds sparse float, which the contract rejects -- see
+    check_estimator_sparse_array in _EXPECTED_FAILED_CHECKS).
+    Currently, the lazy classifiers are dense-only (sparse tag False); their
+    sparse handling is covered by check_estimator_sparse_tag instead,
+    so they are skipped here.
     """
+    if not get_tags(estimator_orig).input_tags.sparse:
+        return
     X, y = _binary_Xy(n_samples=40)
     X = _enforce_estimator_tags_X(estimator_orig, X)
     X = sparse_type(X)
@@ -711,6 +735,8 @@ def check_f_contiguous_array_estimator(name, estimator_orig):
 
 
 def check_transformer_general(name, transformer_orig):
+    if not hasattr(transformer_orig, "transform"):
+        return
     X, y = _binary_Xy(n_samples=30)
     X = _enforce_estimator_tags_X(transformer_orig, X)
     _check_transformer_binary(name, transformer_orig, X, y)
@@ -800,7 +826,9 @@ def check_transformer_preserve_dtypes(name, transformer_orig):
     # Check that dtype is preserved: bool in -> bool out. scihfs accepts only
     # bool, so bool is the single supported dtype to preserve (sklearn iterates
     # transformer_tags.preserves_dtype, which lists float dtypes the contract
-    # rejects).
+    # rejects). Classifier-only estimators have no transform.
+    if not hasattr(transformer_orig, "transform"):
+        return
     transformer = clone(transformer_orig)
     X, y = _binary_Xy(n_samples=30)
     X = _enforce_estimator_tags_X(transformer_orig, X)

--- a/scihfs/tests/test_sklearn_conformance.py
+++ b/scihfs/tests/test_sklearn_conformance.py
@@ -180,12 +180,20 @@ _N_FEATURES = _HIERARCHY.shape[0]
 def _binary_Xy(n_samples, random_state=0):
     """Bool X (width-matched to the hierarchy) and a binary y.
 
-    The bool/width-matched stand-in for the float data sklearn's checks
+    The bool/float-matched stand-in for the float data sklearn's checks
     generate: same role, but contract-compliant and shaped to the hierarchy.
     """
     rng = np.random.RandomState(random_state)
     X = rng.randint(0, 2, size=(n_samples, _N_FEATURES)).astype(bool)
     y = rng.randint(0, 2, size=n_samples)
+    if y[0] != 0:
+        # sklearn's _enforce_estimator_tags_y (called below on this y) relabels
+        # non-binary-tolerant classifiers' y to exactly two classes. Before
+        # sklearn 1.7 it kept whatever value sits at y[0] and remapped the rest
+        # to y[0] + 1; from 1.7 it keys off y.min() instead. Forcing y[0] == 0
+        # (already the min, since y is drawn from {0, 1}) makes both versions
+        # agree and leaves y as {0, 1}, per scihfs's binary-target contract.
+        y = 1 - y
     return X, y
 
 


### PR DESCRIPTION
- Branched out the hierarchy processing components from _HierarchicalEstimator_ and moved them to a new `HierarchyMixin` class (from which both _HierarchicalEstimator_ and the lazy base class now inherit).
- **Redesigned the lazy base class**:
    - As embedded feature selection methods, inheritance from ClassifierMixin was added, which enables the implementation of common `.fit()` / `.predict()` / `.predict_proba()` methods (instead of the previous custom _fit_selector_ and _select_and_predict_ methods).
    - _fit_ now allows subclasses to add a `._fit()` method that can further specify the actions during a common computation phase.
    - _predict_ cascades to `._select_and_predict_proba()`, and subsequently to `._select_features_per_instance()` – which is an abstract method and thus needs to be implemented by all subclasses. This is where the actual lazy selection of features takes place (per test instance).
    - Since the actual selected features are not supposed to change after calling _fit_, the _predict_ function allows for returning the features selected per instance via a `return_masks=True` option (default: _False_).
    - There is no more option to swap the classifier in the lazy classes, as Naive Bayes variations are the only type of classifier that the lazy HFS methods foresee. Henceforth, these need to be implemented as part of the individual methods.
    - The Bernoulli Naive Bayes classifier has been slightly modified: It still allows to learn conditional probabilities on the entire (lazy) training set once during _fit_, whilst using only the selected features per instance (using a mask on the totality of all features) to perform the prediction at _predict_ time. It is initialized with _binarize=False_, but as a private class does not allow for further parameter tuning.
    - _select_ has been kept for now to yield the selected features per instance, but without performing the actual prediction step. This feature will probably be removed in the future, as the features selected in the lazy HFS methods are not supposed to be used outside of their classification logic.
- Added sparse support for all lazy HFS methods – but only at the input interface, not internally. Adding this to save memory would be a todo for the future.
- Binary target encoding (_y_) is now enforced for both eager and lazy methods – both with a dedicated check (`check_binary_target`) and an sklearn tag. Targets can now both be either numerical ‘0’/‘1’ or boolean ‘False’/‘True’ to comply.
- The check for correct 0-1 propagation (_check_data_) has been removed from the repository. Rationale is that the correct propagation is already part of the preprocessor, which is supposed to be run prior to running the actual HFS algorithms.
- Some of the more specific metrics that are not sklearn standard, but which are used extensively throughout the lazy HFS literature, have been moved to the metrics helper module. (More metrics may be added there in the future.)
- Computing relevance of individual features in the hierarchy and subsequent sorting now live in separate lazy base methods.
- Removed an unused code segment in the MR implementation.
- Fixed a bug that could potentially produce an IndexError when columns in X and the hierarchy nodes don’t match. Both lazy AND eager HFS methods now check for column misalignment before fitting.


Added corresponding tests (LLM-generated, manually validated) to lock behavior.

Closes #56 #127 #129 #130 
Partially addresses #55 #128 