### PR TITLE
End-to-end support for sparse in lazy (and eager) methods.

### DIFF
--- a/examples/lazy_learning_example.py
+++ b/examples/lazy_learning_example.py
@@ -105,3 +105,22 @@ model.fit(df_train, y_train)
 print("auto-derived column->node mapping:", model.get_columns())
 print("predictions:", model.predict(df_test))
 print("selection masks (plain ndarray):\n", model.select(df_test))
+
+# %%
+# Sparse input: Input data and masks stay sparse
+# --------------------------------------------------------
+# Lazy's ``fit`` and ``predict``/``select`` all accept sparse input and keep it sparse
+# throughout their internal processing.
+
+import scipy.sparse as sp
+
+model = HNB(hierarchy=hierarchy, k=3).fit(sp.csr_array(X_train), y_train)
+sparse_masks = model.select(sp.csr_array(X_test))
+
+print("predictions:", model.predict(sp.csr_array(X_test)))
+print("selection masks (sparse):", repr(sparse_masks))
+# The metrics take the sparse masks directly, without densifying them.
+print("mean selected fraction:", mean_selected_fraction(sparse_masks))
+
+# Dense input still yields a plain ndarray.
+print("same selection, dense input:\n", model.select(X_test))

--- a/scihfs/helpers.py
+++ b/scihfs/helpers.py
@@ -270,12 +270,16 @@ def get_columns_for_numpy_hierarchy(hierarchy: nx.DiGraph, num_columns: int):
 
 
 def compute_aggregated_values(X, hierarchy: nx.DiGraph, columns: list[int], node="ROOT"):
-    """Recursively aggregate features in X by summing up their children's values.
+    """Aggregate features in X by summing up their children's values/number
+    of occurrences.
 
     The method traverses the given Directed Acyclic Graph (DAG) hierarchy
     starting from the specified node, and recursively aggregates the values
     from its children nodes up to the specified root node. To caculate all
     values start form "ROOT".
+
+    Dispatcher-only: Sparse and dense input need different computation strategies.
+    Those are implemented in the ``_compute_aggregated_values_{dense,sparse}`` functions.
 
     Parameters
     ----------
@@ -294,29 +298,91 @@ def compute_aggregated_values(X, hierarchy: nx.DiGraph, columns: list[int], node
 
     Returns
     ----------
-    X : numpy.ndarray
+    X : numpy.ndarray or scipy.sparse.csc_array
         The input array `X` with the aggregated values based on the provided
-        hierarchy.
+        hierarchy. Sparse input yields a sparse (csc_array) result; dense
+        input yields a numpy.ndarray.
     """
-    # Sparse input is accepted throughout the library, but
-    # currently 'densified' here. To avoid excessive memory
-    # allocation, add a dedicated sparse implementation here in
-    # the future.
     if sp.issparse(X):
-        X = X.toarray()
+        return _compute_aggregated_values_sparse(X, hierarchy, columns, node)
+    return _compute_aggregated_values_dense(X, hierarchy, columns, node)
+
+
+def _compute_aggregated_values_dense(X, hierarchy, columns, node="ROOT"):
     # Note that we deliberately use uint32 (unsigned, min 0, max 4294967295), to keep memory footprint low and because feature counts are always positive integers.
     if X.dtype == np.bool_:
         X = X.astype(np.uint32)
+    # node -> column index, precomputed once so the recursion is O(1).
+    column_of = {n: i for i, n in enumerate(columns)}
+    return _aggregate_dense(X, hierarchy, column_of, node)
+
+
+def _aggregate_dense(X, hierarchy, column_of, node):
+    # Recursive aggregation of node values (occurrences) along the hierarchy,
+    # dense format.
     if hierarchy.out_degree(node) == 0:
         return X
-    children = hierarchy.successors(node)
     aggregated = np.zeros((X.shape[0]), dtype=np.uint32)
-    for child in list(children):
-        X = compute_aggregated_values(X, hierarchy, columns, node=child)
-        aggregated = np.add(aggregated, X[:, columns.index(child)])
+    for child in list(hierarchy.successors(node)):
+        X = _aggregate_dense(X, hierarchy, column_of, child)
+        aggregated = np.add(aggregated, X[:, column_of[child]])
 
     if node != "ROOT":
-        aggregated = np.add(aggregated, X[:, columns.index(node)])
-        column_index = columns.index(node)
-        X[:, column_index] = aggregated
+        aggregated = np.add(aggregated, X[:, column_of[node]])
+        X[:, column_of[node]] = aggregated
     return X
+
+
+def _compute_aggregated_values_sparse(X, hierarchy, columns, node="ROOT"):
+    X = X.tocsc()
+    column_of = {n: i for i, n in enumerate(columns)}
+    cache = {}
+    _aggregate_sparse(X, hierarchy, column_of, node, cache)
+    return _assemble_sparse(X, cache)
+
+
+def _aggregate_sparse(X, hierarchy, column_of, node, cache):
+    # Recursive aggregation of node values (occurrences) along the hierarchy,
+    # sparse format.
+    # Overwriting in-place is not cheap for CSC, so a transient dense vector
+    # is written to 'cache' (internal non-leaf nodes only) before assembling
+    # a sparse matrix once at the end.
+    if hierarchy.out_degree(node) == 0:
+        return
+    aggregated = np.zeros(X.shape[0], dtype=np.uint32)
+    for child in list(hierarchy.successors(node)):
+        _aggregate_sparse(X, hierarchy, column_of, child, cache)
+        aggregated = np.add(aggregated, _sparse_column_uint32(X, column_of, child, cache))
+
+    if node != "ROOT":
+        aggregated = np.add(aggregated, _sparse_column_uint32(X, column_of, node, cache))
+        cache[column_of[node]] = aggregated
+
+
+def _sparse_column_uint32(X, column_of, node, cache):
+    # Returns a column with values converted to uint32 to allow summation
+    # (and the pre-aggregated value if the column had already been visited
+    # in a previous pass).
+    index = column_of[node]
+    if index in cache:
+        return cache[index]
+    column = X[:, index].toarray().ravel()
+    return column.astype(np.uint32) if column.dtype == np.bool_ else column
+
+
+def _assemble_sparse(X, cache):
+    # Reassembles the sparse matrix (with uint32 values) from the cache
+    # and the original (leaf) columns of X.
+    # Added a cache.pop to reduce peak memory usage when appending to the
+    # blocks variable.
+    n_features = X.shape[1]
+    blocks = []
+    for index in range(n_features):
+        if index in cache:  # already aggregated (non-leaf) nodes/features
+            blocks.append(sp.csc_array(cache.pop(index).reshape(-1, 1)))
+        else:  # original (leaf) nodes/features
+            column = X[:, [index]]
+            blocks.append(
+                column.astype(np.uint32) if column.dtype == np.bool_ else column
+            )
+    return sp.hstack(blocks, format="csc")

--- a/scihfs/helpers.py
+++ b/scihfs/helpers.py
@@ -15,38 +15,44 @@ from sklearn.utils.multiclass import type_of_target
 
 def get_relevance(xdata, ydata, node):
     """
-    Gather relevance for a given node.
+    Calculate the relevance for a single node.
+
+    Based on the column counts for feature present/absent,
+    and how often presence/absence correlates with positive/negative
+    target labels. Sparse is densified only per single column.
 
     Parameters
     ----------
-    node : int
-        Node for which the relevance should be obtained.
     xdata : {array-like, sparse matrix}, shape (n_samples, n_features)
             The training input samples.
     ydata : array-like, shape (n_samples,)
             The target values. An array of int.
-    """
-    p1 = (
-        Fraction(
-            xdata[(xdata[:, node] == 1) & (ydata == 1)].shape[0],
-            xdata[(xdata[:, node] == 1)].shape[0],
-        )
-        if xdata[(xdata[:, node] == 1)].shape[0] != 0
-        else 0
-    )
-    p2 = (
-        Fraction(
-            xdata[(xdata[:, node] == 0) & (ydata == 1)].shape[0],
-            xdata[(xdata[:, node] == 0)].shape[0],
-        )
-        if xdata[(xdata[:, node] == 0)].shape[0] != 0
-        else 0
-    )
-    p3 = 1 - p1
-    p4 = 1 - p2
+    node : int
+        Node for which the relevance should be obtained.
 
-    rel = (p1 - p2) ** 2 + (p3 - p4) ** 2
-    return rel
+    Returns
+    ----------
+    relevance : Fraction or int
+        The relevance score of the node.
+    """
+    # List index slice covers ndarray, sparse matrices and sparse arrays
+    # with a single function.
+    column = xdata[:, [node]].toarray().ravel() if sp.issparse(xdata) else xdata[:, node]
+    present = column == 1
+    positive_target = np.asarray(ydata) == 1
+
+    n_present = int(np.count_nonzero(present))
+    n_absent = column.shape[0] - n_present
+    n_present_positive = int(np.count_nonzero(present & positive_target))
+    n_absent_positive = int(np.count_nonzero(positive_target)) - n_present_positive
+
+    # Renamed the variables to match contingency table notation.
+    # Cf. pX notation from the paper in the inline comments.
+    ppv = Fraction(n_present_positive, n_present) if n_present else 0  # p1 = 1 - p3
+    fomr = Fraction(n_absent_positive, n_absent) if n_absent else 0  # p2 = 1 - p4
+
+    relevance = 2 * (ppv - fomr) ** 2
+    return relevance
 
 
 def check_bool_dtype(X):

--- a/scihfs/metrics.py
+++ b/scihfs/metrics.py
@@ -273,14 +273,17 @@ def mean_selected_fraction(masks):
 
     Parameters
     ----------
-    masks : array-like of shape (n_samples, n_features), dtype bool
-        The per-instance selection masks, as returned by a lazy selector's
-        ``select`` method.
+    masks : {array-like, sparse matrix} of shape (n_samples, n_features), dtype bool
+        The per-instance selection masks, as returned by a lazy selector's ``select``
+        method (or ``predict`` with return_masks=True set).
 
     Returns
     ----------
     float : The mean fraction of selected features per instance, in [0, 1].
     """
+    if sparse.issparse(masks):
+        n_samples, n_features = masks.shape
+        return float(masks.count_nonzero() / (n_samples * n_features))
     masks = np.asarray(masks, dtype=bool)
     return float(masks.mean())
 

--- a/scihfs/metrics.py
+++ b/scihfs/metrics.py
@@ -299,4 +299,10 @@ def pearson_correlation(i: np.ndarray, j: np.ndarray):
     ----------
     float : The pearson correlation between the input vectors.
     """
+    # Since np.corrcoef has no sparse support, densify the two (n_samples,)
+    # columns at their time of comparison (and not the full feature matrix).
+    if sparse.issparse(i):
+        i = i.toarray().ravel()
+    if sparse.issparse(j):
+        j = j.toarray().ravel()
     return np.corrcoef(i, j)[0, 1]

--- a/scihfs/selectors/eagerHierarchicalFeatureSelector.py
+++ b/scihfs/selectors/eagerHierarchicalFeatureSelector.py
@@ -16,7 +16,7 @@ class EagerHierarchicalFeatureSelector(SelectorMixin, HierarchicalEstimator):
     Eager selectors are supervised: ``fit`` requires a target ``y``.
     Subclasses implement their selection algorithm in ``_select``, which
     runs after the single input-validation pass and the hierarchy setup
-    and fills ``representatives_`` with the names of all hierarchy nodes
+    and fills ``selected_features_`` with the names of all hierarchy nodes
     that are left after feature selection.
 
     A DataFrame passed to ``fit`` together with a named ``nx.DiGraph``
@@ -41,14 +41,14 @@ class EagerHierarchicalFeatureSelector(SelectorMixin, HierarchicalEstimator):
     def _fit(self, X, y):
         """Runs the eager feature selection on the validated X and y.
 
-        Rejects a hierarchy/column mismatch, resets ``representatives_`` and
+        Rejects a hierarchy/column mismatch, resets ``selected_features_`` and
         delegates to the subclasses' ``_select``.
         """
         self._reject_column_node_mismatch()
 
-        # self.representatives_ includes all node names for selected nodes.
+        # self.selected_features_ includes all node names for selected nodes.
         # self._columns maps them to the respective column in X.
-        self.representatives_ = []
+        self.selected_features_ = []
         self._select(X, y)
 
     @abstractmethod
@@ -56,19 +56,17 @@ class EagerHierarchicalFeatureSelector(SelectorMixin, HierarchicalEstimator):
         """The subclass's feature selection algorithm.
 
         Called with the validated X and y after the hierarchy setup, and
-        expected to fill ``self.representatives_`` with the names of the
+        expected to fill ``self.selected_features_`` with the names of the
         selected hierarchy nodes.
         """
 
     def _get_support_mask(self):
         # Implements _get_support_mask method from SelectorMixin to
         # indicate the selected features from X.
-        representatives_indices = [
-            self._column_index(node) for node in self.representatives_
-        ]
+        selected_indices = [self._column_index(node) for node in self.selected_features_]
         return np.asarray(
             [
-                True if index in representatives_indices else False
+                True if index in selected_indices else False
                 for index in range(self.n_features_in_)
             ]
         )

--- a/scihfs/selectors/gtd.py
+++ b/scihfs/selectors/gtd.py
@@ -76,7 +76,7 @@ class GreedyTopDownSelector(EagerHierarchicalFeatureSelector):
             # all their descendants and ancestors
             while branch_nodes:
                 selected = branch_nodes.pop(0)
-                self.representatives_.append(selected)
+                self.selected_features_.append(selected)
                 remove_nodes = list(nx.descendants(self._hierarchy_graph, selected))
                 ancestor_nodes = list(nx.ancestors(self._hierarchy_graph, selected))
                 remove_nodes.extend(ancestor_nodes)

--- a/scihfs/selectors/hie_aode.py
+++ b/scihfs/selectors/hie_aode.py
@@ -1,5 +1,6 @@
 import networkx as nx
 import numpy as np
+import scipy.sparse as sp
 
 from .lazyHierarchicalFeatureSelector import LazyHierarchicalFeatureSelector
 
@@ -12,6 +13,9 @@ class HieAODE(LazyHierarchicalFeatureSelector):
 
     def _fit(self, X, y):
         """Allocate the conditional-probability tables from the fitted shapes."""
+        # TEMPORARY densification. Will be removed upon overhaul of this class.
+        if sp.issparse(self._xtrain):
+            self._xtrain = self._xtrain.toarray()
         self.cpts = dict(
             prior=np.full((self.n_features_in_, self.n_classes_, 2), -1),
             # (x_j (descendent), x_i (current feature), class, value)  # P(y, x_i )
@@ -33,6 +37,9 @@ class HieAODE(LazyHierarchicalFeatureSelector):
     def predict(self, X):
         """Predict the target value for each instance in X using HieAODE."""
         X = self._check_and_validate(X)
+        # TEMPORARY densification. Will be removed upon overhaul of this class.
+        if sp.issparse(X):
+            X = X.toarray()
         n_samples = X.shape[0]
         sample_sum = np.zeros((n_samples, self.n_classes_))
         for sample_idx in range(n_samples):

--- a/scihfs/selectors/hill_climbing.py
+++ b/scihfs/selectors/hill_climbing.py
@@ -383,9 +383,13 @@ class BottomUpSelector(HillClimbingSelector):
         return self._calculate_similarity(sample_i, sample_j, feature_set)
 
     def _calculate_similarity(self, sample_i: int, sample_j: int, feature_set: list[int]):
-        row_i = self._score_matrix[sample_i, feature_set]
-        row_j = self._score_matrix[sample_j, feature_set]
-        return cosine_similarity(row_i.flatten(), row_j.flatten())
+        row_i = self._select_row_for_scoring(sample_i, feature_set)
+        row_j = self._select_row_for_scoring(sample_j, feature_set)
+        return cosine_similarity(row_i, row_j)
+
+    def _select_row_for_scoring(self, sample: int, feature_set: list[int]):
+        row = self._score_matrix[sample, feature_set]
+        return row.toarray().ravel() if sp.issparse(row) else row.flatten()
 
     def _fitness_function(self, comparison_matrix: np.ndarray) -> float:
         # number_of_leaf_nodes is the alpha value from paper.

--- a/scihfs/selectors/hill_climbing.py
+++ b/scihfs/selectors/hill_climbing.py
@@ -60,7 +60,7 @@ class HillClimbingSelector(EagerHierarchicalFeatureSelector):
             X = X.tocsr()
         self.y_ = y
         self._num_rows = X.shape[0]
-        self.representatives_ = self._hill_climb(X)
+        self.selected_features_ = self._hill_climb(X)
 
     @abstractmethod
     def _hill_climb(self, X):

--- a/scihfs/selectors/lazyHierarchicalFeatureSelector.py
+++ b/scihfs/selectors/lazyHierarchicalFeatureSelector.py
@@ -78,7 +78,8 @@ class LazyHierarchicalFeatureSelector(
 
     Sparse input stays sparse: the training set is kept in its sparse form
     for the estimator's lifetime. At predict time only the single instance
-    from the test set currently being classified is densified.
+    from the test set currently being classified is densified, and the
+    selection masks are returned sparse as well.
 
     TEMPORARY: Subclasses whose internals still require a dense matrix densify it
     themselves (currently only TAN and HieAODE).
@@ -223,6 +224,41 @@ class LazyHierarchicalFeatureSelector(
             return X[[row_index]].toarray().ravel()
         return X[row_index]
 
+    @staticmethod
+    def _selected_columns(instance_status):
+        """The selected feature columns of one instance, as a list of int."""
+        return [node for node, selected in instance_status.items() if selected]
+
+    def _build_masks(self, rows, columns, n_samples, as_sparse):
+        """Assemble the per-instance selection masks from the selected positions.
+
+        Parameters
+        ----------
+        rows, columns : list of int
+            The positions of the selected features, as parallel list (COO style).
+        n_samples : int
+            The number of test instances (row count on X_test).
+        as_sparse : bool
+            Whether to return a sparse (CSR) mask. Set from the format of the
+            input X, so that sparse input yields sparse masks and dense input
+            keeps yielding an ndarray.
+
+        Returns
+        -------
+        masks : numpy array or scipy.sparse csr_array of shape \
+(n_samples, n_features), dtype bool
+            ``masks[i, j]`` is True if feature column ``j`` was selected for
+            test instance ``i``.
+        """
+        shape = (n_samples, self.n_features_in_)
+        if as_sparse:
+            return sp.csr_array(
+                (np.ones(len(rows), dtype=bool), (rows, columns)), shape=shape, dtype=bool
+            )
+        masks = np.zeros(shape, dtype=bool)
+        masks[rows, columns] = True
+        return masks
+
     def _select_and_predict_proba(self, X, return_masks):
         """One per-instance sweep of selection + prediction.
 
@@ -237,25 +273,24 @@ class LazyHierarchicalFeatureSelector(
         -------
         proba : numpy array of shape (n_samples, n_classes)
             The per-instance class probabilities, columns ordered by ``classes_``.
-        masks : numpy array of shape (n_samples, n_features), dtype bool, or None
+        masks : numpy array or scipy.sparse csr_array of shape \
+(n_samples, n_features), dtype bool, or None
             The per-instance selection masks when ``return_masks`` is set, else
-            ``None``.
+            ``None``. Sparse iff X is.
         """
         proba = np.empty((X.shape[0], self.n_classes_))
-        masks = (
-            np.zeros((X.shape[0], self.n_features_in_), dtype=bool)
-            if return_masks
-            else None
-        )
+        mask_rows, mask_columns = [], []
         for idx in range(X.shape[0]):
             x_row = self._dense_row(X, idx)
             status = self._select_features_per_instance(x_row)
             proba[idx] = self._predict_proba_per_instance(x_row, status)
             if return_masks:
-                for node, selected in status.items():
-                    # Nodes are data-column indices after fit's relabel.
-                    if selected:
-                        masks[idx, node] = True
+                selected = self._selected_columns(status)
+                mask_rows.extend([idx] * len(selected))
+                mask_columns.extend(selected)
+        if not return_masks:
+            return proba, None
+        masks = self._build_masks(mask_rows, mask_columns, X.shape[0], sp.issparse(X))
         return proba, masks
 
     def predict(self, X, return_masks=False):
@@ -269,7 +304,7 @@ class LazyHierarchicalFeatureSelector(
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
+        X : array-like or scipy.sparse (CSR) of shape (n_samples, n_features)
             The test input samples. Must be bool-dtype.
         return_masks : bool, default=False
             If True, also return the per-instance selection masks, built in the
@@ -280,9 +315,11 @@ class LazyHierarchicalFeatureSelector(
         -------
         predictions : numpy array of shape (n_samples,)
             The predicted target values.
-        masks : numpy array of shape (n_samples, n_features), dtype bool
+        masks : numpy array or scipy.sparse csr_array of shape \
+(n_samples, n_features), dtype bool
             Returned only when ``return_masks`` is True; ``masks[i, j]`` is True
-            iff feature column ``j`` was selected for test instance ``i``.
+            iff feature column ``j`` was selected for test instance ``i``. Sparse
+            iff X is (see ``select``).
         """
         X = self._check_and_validate(X)
         proba, masks = self._select_and_predict_proba(X, return_masks=return_masks)
@@ -316,26 +353,29 @@ class LazyHierarchicalFeatureSelector(
         predictions, without scoring the naive Bayes. Equivalent to the masks
         from ``predict(X, return_masks=True)``.
 
+        The masks follow the format of X: sparse input yields a sparse (CSR)
+        mask, dense input an ndarray.
+
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
+        X : array-like or scipy.sparse (CSR) of shape (n_samples, n_features)
             The test input samples. Must be bool-dtype.
 
         Returns
         -------
-        masks : numpy array of shape (n_samples, n_features), dtype bool
-            ``masks[i, j]`` is True iff feature column ``j`` was selected for
-            test instance ``i``.
+        masks : numpy array or scipy.sparse csr_array of shape \
+(n_samples, n_features), dtype bool
+            ``masks[i, j]`` is True if feature column ``j`` was selected for
+            test instance ``i``. Sparse if X is.
         """
         X = self._check_and_validate(X)
-        masks = np.zeros((X.shape[0], self.n_features_in_), dtype=bool)
+        mask_rows, mask_columns = [], []
         for idx in range(X.shape[0]):
             x_row = self._dense_row(X, idx)
-            for node, selected in self._select_features_per_instance(x_row).items():
-                # Nodes are data-column indices after fit's relabel.
-                if selected:
-                    masks[idx, node] = True
-        return masks
+            selected = self._selected_columns(self._select_features_per_instance(x_row))
+            mask_rows.extend([idx] * len(selected))
+            mask_columns.extend(selected)
+        return self._build_masks(mask_rows, mask_columns, X.shape[0], sp.issparse(X))
 
     @abstractmethod
     def _select_features_per_instance(self, x_row):

--- a/scihfs/selectors/lazyHierarchicalFeatureSelector.py
+++ b/scihfs/selectors/lazyHierarchicalFeatureSelector.py
@@ -75,6 +75,13 @@ class LazyHierarchicalFeatureSelector(
     auto-derives the column->node mapping from the feature names; otherwise an
     explicit ``columns`` mapping needs to be provided (fallback is the positional 1:1
     default).
+
+    Sparse input stays sparse: the training set is kept in its sparse form
+    for the estimator's lifetime. At predict time only the single instance
+    from the test set currently being classified is densified.
+
+    TEMPORARY: Subclasses whose internals still require a dense matrix densify it
+    themselves (currently only TAN and HieAODE).
     """
 
     def __init__(
@@ -110,7 +117,7 @@ class LazyHierarchicalFeatureSelector(
         ----------
         X : array-like or scipy.sparse (CSR) of shape (n_samples, n_features)
             The training input samples. Must be bool-dtype. Sparse input is
-            densified internally (for now).
+            kept sparse.
         y : array-like of shape (n_samples,)
             The target values.
         columns : list or None
@@ -128,8 +135,6 @@ class LazyHierarchicalFeatureSelector(
         """
         X, y = validate_data(self, X, y, accept_sparse="csr")
         check_binary_target(y)
-        if sp.issparse(X):
-            X = X.toarray()
         check_bool_dtype(X)
         self.classes_ = np.unique(y)
         self.n_classes_ = self.classes_.shape[0]
@@ -159,11 +164,13 @@ class LazyHierarchicalFeatureSelector(
 
         Parameters
         ----------
-        X : numpy array of shape (n_samples, n_features)
+        X : numpy array or scipy.sparse of shape (n_samples, n_features)
             The training input samples.
         y : numpy array of shape (n_samples,)
             The target values.
         """
+        if sp.issparse(X):
+            X = X.tocsc()
         self._relevance = {
             node: get_relevance(X, y, node) for node in self._hierarchy_graph
         }
@@ -180,28 +187,48 @@ class LazyHierarchicalFeatureSelector(
     def _check_and_validate(self, X):
         """Shared function for input validation.
 
-        Sparse input (CSR) is accepted and densified: the per-instance selection
-        algorithms index single rows as dense, so the classifiers accept sparse
-        at the boundary but work on a dense copy internally.
+        Sparse input (CSR) is accepted and kept sparse; the per-instance
+        selection algorithms are fed one densified row at a time (see
+        ``_dense_row``).
 
         Returns
         -------
-        X : numpy array
-            The validated (and densified) test input.
+        X : numpy array or scipy.sparse
+            The validated test input, remains dense/sparse if input was dense/sparse.
         """
         check_is_fitted(self)
         X = validate_data(self, X, accept_sparse="csr", reset=False)
-        if sp.issparse(X):
-            X = X.toarray()
         check_bool_dtype(X)
         return X
+
+    @staticmethod
+    def _dense_row(X, row_index):
+        """Return one instance of X as a dense 1-D array.
+
+        Required for downstream processing per instance.
+
+        Parameters
+        ----------
+        X : numpy array or scipy.sparse of shape (n_samples, n_features)
+            The validated input samples.
+        row_index : int
+            The row to extract.
+
+        Returns
+        -------
+        x_row : numpy array of shape (n_features,)
+            The instance as a dense array.
+        """
+        if sp.issparse(X):
+            return X[[row_index]].toarray().ravel()
+        return X[row_index]
 
     def _select_and_predict_proba(self, X, return_masks):
         """One per-instance sweep of selection + prediction.
 
         Parameters
         ----------
-        X : numpy array of shape (n_samples, n_features)
+        X : numpy array or scipy.sparse of shape (n_samples, n_features)
             The validated test input samples.
         return_masks : bool
             Whether to also build the per-instance selection masks.
@@ -221,8 +248,9 @@ class LazyHierarchicalFeatureSelector(
             else None
         )
         for idx in range(X.shape[0]):
-            status = self._select_features_per_instance(X[idx])
-            proba[idx] = self._predict_proba_per_instance(X[idx], status)
+            x_row = self._dense_row(X, idx)
+            status = self._select_features_per_instance(x_row)
+            proba[idx] = self._predict_proba_per_instance(x_row, status)
             if return_masks:
                 for node, selected in status.items():
                     # Nodes are data-column indices after fit's relabel.
@@ -302,7 +330,8 @@ class LazyHierarchicalFeatureSelector(
         X = self._check_and_validate(X)
         masks = np.zeros((X.shape[0], self.n_features_in_), dtype=bool)
         for idx in range(X.shape[0]):
-            for node, selected in self._select_features_per_instance(X[idx]).items():
+            x_row = self._dense_row(X, idx)
+            for node, selected in self._select_features_per_instance(x_row).items():
                 # Nodes are data-column indices after fit's relabel.
                 if selected:
                     masks[idx, node] = True

--- a/scihfs/selectors/shsel.py
+++ b/scihfs/selectors/shsel.py
@@ -151,7 +151,7 @@ class SHSELSelector(EagerHierarchicalFeatureSelector):
                 if similarity >= self._effective_threshold:
                     nodes_to_remove.add(node)
 
-        self.representatives_ = [
+        self.selected_features_ = [
             feature for feature in self._columns if feature not in nodes_to_remove
         ]
 
@@ -162,21 +162,21 @@ class SHSELSelector(EagerHierarchicalFeatureSelector):
                 f"Unknown ig_average {self.ig_average!r}; "
                 'expected "full_path" or "survivors_only".'
             )
-        updated_representatives = []
+        updated_selected_features = []
 
         for path in paths:
             path.remove("ROOT")
             if self.ig_average == "full_path":
                 average_nodes = path
             else:
-                average_nodes = [node for node in path if node in self.representatives_]
+                average_nodes = [node for node in path if node in self.selected_features_]
             average_relevance = statistics.mean(
                 [self._relevance_values[node] for node in average_nodes]
             )
             average_relevance = round(average_relevance, 6)
             for node in path:
                 if (
-                    node in self.representatives_
+                    node in self.selected_features_
                     and self._relevance_values[node] >= average_relevance
                 ):
                     # HFE extension disabled:
@@ -184,9 +184,11 @@ class SHSELSelector(EagerHierarchicalFeatureSelector):
                     #     self.use_hfe_extension is False
                     #     or self._relevance_values[node] > 0.0
                     # ):
-                    updated_representatives.append(node)
+                    updated_selected_features.append(node)
 
-        self.representatives_ = list(set(updated_representatives))  # remove duplicates
+        self.selected_features_ = list(
+            set(updated_selected_features)
+        )  # remove duplicates
 
     def _calculate_ig_relevance(self, X, y):
         values = information_gain(X, y)
@@ -212,12 +214,12 @@ class SHSELSelector(EagerHierarchicalFeatureSelector):
     #     )
     #
     # def _leaf_filtering(self):
-    #     """Filtering representatives by removing leaves with low relevance.
+    #     """Filtering selected features by removing leaves with low relevance.
     #
     #     This is part of the HFE extension proposed by Oudah and Henschel.
     #     """
     #     average_ig = statistics.mean(
-    #         [self._relevance_values[node] for node in self.representatives_]
+    #         [self._relevance_values[node] for node in self.selected_features_]
     #     )
     #
     #     leaves = self._get_leaves_in_incomplete_paths()
@@ -228,17 +230,17 @@ class SHSELSelector(EagerHierarchicalFeatureSelector):
     #         if self._relevance_values[leaf] < average_ig
     #         or self._relevance_values[leaf] == 0
     #     ]
-    #     updated_representatives = [
-    #         node for node in self.representatives_ if node not in nodes_to_remove
+    #     updated_selected_features = [
+    #         node for node in self.selected_features_ if node not in nodes_to_remove
     #     ]
-    #     self.representatives_ = updated_representatives
+    #     self.selected_features_ = updated_selected_features
     #
     # def _get_leaves_in_incomplete_paths(self):
     #     """Select leaves of incomplete paths (part of HFE extension)"""
     #     leaves = [
     #         leaf
     #         for leaf in get_leaves(self._hierarchy_graph)
-    #         if leaf in self.representatives_
+    #         if leaf in self.selected_features_
     #     ]
     #
     #     paths = get_paths(self._hierarchy_graph)

--- a/scihfs/selectors/tan.py
+++ b/scihfs/selectors/tan.py
@@ -2,6 +2,7 @@
 
 import networkx as nx
 import numpy as np
+import scipy.sparse as sp
 
 from scihfs.metrics import conditional_mutual_information
 
@@ -17,6 +18,9 @@ class TAN(LazyHierarchicalFeatureSelector):
     """
 
     def _fit(self, X, y):
+        # TEMPORARY densification. Will be removed upon overhaul of this class.
+        if sp.issparse(self._xtrain):
+            self._xtrain = self._xtrain.toarray()
         self._build_mst()
 
     def _build_mst(self):

--- a/scihfs/selectors/tsel.py
+++ b/scihfs/selectors/tsel.py
@@ -51,7 +51,7 @@ class TSELSelector(EagerHierarchicalFeatureSelector):
             column_name: lift_values[index]
             for index, column_name in enumerate(self._columns)
         }
-        self.representatives_ = self._find_representatives(paths)
+        self.selected_features_ = self._find_representatives(paths)
 
     def _find_representatives(self, paths):
         """ "Finds a representative node for each path.

--- a/scihfs/tests/test_eager_base.py
+++ b/scihfs/tests/test_eager_base.py
@@ -118,7 +118,7 @@ class _SelectNodesACSelector(EagerHierarchicalFeatureSelector):
     """Concrete stub whose _select always keeps hierarchy nodes A (0) and C (2)."""
 
     def _select(self, X, y):
-        self.representatives_ = [0, 2]
+        self.selected_features_ = [0, 2]
 
 
 def test_get_feature_names_out_from_dataframe():

--- a/scihfs/tests/test_feature_selection_filter.py
+++ b/scihfs/tests/test_feature_selection_filter.py
@@ -153,7 +153,11 @@ def test_lazy_selectors_accept_sparse_like_dense(lazy_data2, factory, sparse_typ
     sparse_fit = factory(small_DAG).fit(sparse_type(X_train), y_train)
 
     assert np.array_equal(sparse_fit.predict(sparse_type(X_test)), dense.predict(X_test))
-    assert np.array_equal(sparse_fit.select(sparse_type(X_test)), dense.select(X_test))
+    # select mirrors the input format, so sparse input returns a sparse mask;
+    # densify it here to compare the selections themselves.
+    sparse_masks = sparse_fit.select(sparse_type(X_test))
+    assert sp.issparse(sparse_masks)
+    assert np.array_equal(sparse_masks.toarray(), dense.select(X_test))
 
 
 # The selectors that work on sparse X end-to-end. TAN and HieAODE are excluded
@@ -213,6 +217,81 @@ def test_lazy_selectors_select_on_dense_rows_of_sparse_input(lazy_data2, factory
     assert len(seen_rows) == X_test.shape[0]
     assert all(isinstance(row, np.ndarray) for row in seen_rows)
     assert all(row.shape == (X_train.shape[1],) for row in seen_rows)
+
+
+# ---------------------------------------------------------------------------
+# Selection masks mirror the input format.
+#
+# A mask of selected features is inherently sparse -- so on a large sparse
+# problem a dense mask would have equal memory consumption than the data.
+# Sparse X therefore yields a sparse mask, while dense X keeps returning an
+# ndarray so existing callers are unaffected.
+# The format follows the X handed to select/predict (not the one used in fit).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("factory", _SPARSE_NATIVE_FACTORIES, ids=_SPARSE_NATIVE_IDS)
+def test_select_masks_mirror_input_format(lazy_data2, factory):
+    small_DAG, X_train, y_train, X_test, _ = lazy_data2
+    # Deliberately fitted on dense data: the mask format follows the test input.
+    selector = factory(small_DAG).fit(X_train, y_train)
+
+    dense_masks = selector.select(X_test)
+    sparse_masks = selector.select(sp.csr_array(X_test))
+
+    assert isinstance(dense_masks, np.ndarray)
+    assert dense_masks.dtype == bool
+    assert sp.issparse(sparse_masks)
+    assert sparse_masks.dtype == bool
+    assert sparse_masks.shape == dense_masks.shape
+    assert np.array_equal(sparse_masks.toarray(), dense_masks)
+
+
+@pytest.mark.parametrize("factory", _SPARSE_NATIVE_FACTORIES, ids=_SPARSE_NATIVE_IDS)
+def test_predict_return_masks_mirror_input_format(lazy_data2, factory):
+    # predict(return_masks=True) builds the masks in the same sweep as the
+    # predictions, so it must follow the same rule as select().
+    small_DAG, X_train, y_train, X_test, _ = lazy_data2
+    selector = factory(small_DAG).fit(sp.csr_array(X_train), y_train)
+
+    _, sparse_masks = selector.predict(sp.csr_array(X_test), return_masks=True)
+    _, dense_masks = selector.predict(X_test, return_masks=True)
+
+    assert sp.issparse(sparse_masks)
+    assert isinstance(dense_masks, np.ndarray)
+    assert np.array_equal(sparse_masks.toarray(), dense_masks)
+    # ... and both still agree with the standalone select().
+    assert np.array_equal(dense_masks, selector.select(X_test))
+
+
+def test_build_masks_handles_empty_selection(lazy_data2):
+    # Nothing selected for any instance: the sparse branch then builds from
+    # empty coordinate lists, which must still give a correctly shaped
+    # all-False mask rather than a degenerate or 0x0 one.
+    small_DAG, X_train, y_train, X_test, _ = lazy_data2
+    selector = HNB(hierarchy=small_DAG, k=2).fit(X_train, y_train)
+    n_samples = X_test.shape[0]
+    expected_shape = (n_samples, X_train.shape[1])
+
+    dense_masks = selector._build_masks([], [], n_samples, as_sparse=False)
+    sparse_masks = selector._build_masks([], [], n_samples, as_sparse=True)
+
+    assert dense_masks.shape == expected_shape
+    assert not dense_masks.any()
+    assert sparse_masks.shape == expected_shape
+    assert sparse_masks.count_nonzero() == 0
+
+
+def test_mean_selected_fraction_matches_across_mask_formats(lazy_data2):
+    # The metric is the main consumer of the masks and previously raised
+    # ValueError on sparse input (np.asarray on a sparse matrix).
+    small_DAG, X_train, y_train, X_test, _ = lazy_data2
+    selector = HNB(hierarchy=small_DAG, k=2).fit(X_train, y_train)
+
+    dense_fraction = mean_selected_fraction(selector.select(X_test))
+    sparse_fraction = mean_selected_fraction(selector.select(sp.csr_array(X_test)))
+
+    assert dense_fraction == sparse_fraction == 0.5
 
 
 # ---------------------------------------------------------------------------

--- a/scihfs/tests/test_feature_selection_filter.py
+++ b/scihfs/tests/test_feature_selection_filter.py
@@ -127,10 +127,14 @@ def test_lazy_selectors_honour_non_identity_columns(lazy_data2, factory):
 # ---------------------------------------------------------------------------
 # Sparse (CSR-bool) input must match dense input exactly.
 #
-# The lazy classifiers accept scipy.sparse at the validate_data boundary and
-# densify internally, so fitting and predicting on a CSR-bool copy of the data
-# must reproduce the dense predict / select exactly (same fit, same per-instance
-# selection, same scoring). Both CSR containers (array and matrix) are covered.
+# The lazy classifiers keep scipy.sparse input sparse end-to-end (only the
+# instance currently being classified is densified), so fitting and predicting
+# on a CSR-bool copy of the data must reproduce the dense predict / select
+# exactly (same fit, same per-instance selection, same scoring). Both CSR
+# containers (array and matrix) are covered.
+#
+# Equivalence alone would still hold if the classifiers densified internally,
+# so the tests below it pin the memory behaviour itself.
 # ---------------------------------------------------------------------------
 
 
@@ -150,6 +154,65 @@ def test_lazy_selectors_accept_sparse_like_dense(lazy_data2, factory, sparse_typ
 
     assert np.array_equal(sparse_fit.predict(sparse_type(X_test)), dense.predict(X_test))
     assert np.array_equal(sparse_fit.select(sparse_type(X_test)), dense.select(X_test))
+
+
+# The selectors that work on sparse X end-to-end. TAN and HieAODE are excluded
+# on purpose: they densify for themselves (see the test below).
+_SPARSE_NATIVE_FACTORIES = [
+    lambda h: HIP(h),
+    lambda h: HNB(hierarchy=h, k=2),
+    lambda h: HNBs(hierarchy=h),
+    lambda h: RNB(hierarchy=h, k=2),
+    lambda h: MR(h),
+]
+_SPARSE_NATIVE_IDS = ["HIP", "HNB", "HNBs", "RNB", "MR"]
+
+
+@pytest.mark.parametrize("factory", _SPARSE_NATIVE_FACTORIES, ids=_SPARSE_NATIVE_IDS)
+def test_lazy_selectors_store_training_data_sparse(lazy_data2, factory):
+    # The training matrix is retained for the estimator's lifetime, so
+    # densifying it at fit time would cost O(n_samples * n_features) for as
+    # long as the estimator lives. It must stay in its sparse form.
+    small_DAG, X_train, y_train, _, _ = lazy_data2
+    selector = factory(small_DAG).fit(sp.csr_array(X_train), y_train)
+    assert sp.issparse(selector._xtrain)
+
+
+@pytest.mark.parametrize(
+    "factory", [lambda h: TAN(h), lambda h: HieAODE(h)], ids=["TAN", "HieAODE"]
+)
+def test_dense_only_selectors_densify_training_data_themselves(lazy_data2, factory):
+    # TAN and HieAODE index columns/rows densely and carry dense
+    # O(n_features**2) structures, so each densifies the training matrix in its
+    # own _fit rather than the base class doing it for everyone. Pinning that
+    # keeps it deliberate rather than accidental: when either is reworked, this
+    # test is the reminder to drop its local .toarray().
+    small_DAG, X_train, y_train, _, _ = lazy_data2
+    selector = factory(small_DAG).fit(sp.csr_array(X_train), y_train)
+    assert isinstance(selector._xtrain, np.ndarray)
+
+
+@pytest.mark.parametrize("factory", _SPARSE_NATIVE_FACTORIES, ids=_SPARSE_NATIVE_IDS)
+def test_lazy_selectors_select_on_dense_rows_of_sparse_input(lazy_data2, factory):
+    # The per-instance algorithms index single features (x_row[node]), which a
+    # sparse row slice does not support. Each instance must therefore arrive as
+    # a dense 1-D array -- one row at a time, never the whole test matrix.
+    small_DAG, X_train, y_train, X_test, _ = lazy_data2
+    selector = factory(small_DAG).fit(sp.csr_array(X_train), y_train)
+
+    seen_rows = []
+    select_per_instance = selector._select_features_per_instance
+
+    def record(x_row):
+        seen_rows.append(x_row)
+        return select_per_instance(x_row)
+
+    selector._select_features_per_instance = record
+    selector.predict(sp.csr_array(X_test))
+
+    assert len(seen_rows) == X_test.shape[0]
+    assert all(isinstance(row, np.ndarray) for row in seen_rows)
+    assert all(row.shape == (X_train.shape[1],) for row in seen_rows)
 
 
 # ---------------------------------------------------------------------------

--- a/scihfs/tests/test_helpers.py
+++ b/scihfs/tests/test_helpers.py
@@ -123,6 +123,40 @@ def test_relevance(lazy_data2):
         assert value == results[node_idx]
 
 
+@pytest.mark.parametrize(
+    "sparse_type", [sparse.csr_array, sparse.csr_matrix], ids=["csr_array", "csr_matrix"]
+)
+def test_relevance_accepts_sparse_like_dense(lazy_data2, sparse_type):
+    # Sparse X previously raised TypeError here (the row-subset selections
+    # could not be masked). The scores must not merely be close but identical:
+    # the lazy selectors rank nodes on them, so an exact Fraction is what keeps
+    # the resulting order independent of the input format.
+    small_DAG, train_x_data, train_y_data, _, _ = lazy_data2
+    sparse_x_data = sparse_type(train_x_data)
+    for node_idx in range(len(small_DAG)):
+        dense_value = get_relevance(train_x_data, train_y_data, node_idx)
+        assert get_relevance(sparse_x_data, train_y_data, node_idx) == dense_value
+
+
+def test_relevance_stays_exact_for_tied_nodes():
+    # The score is compared, not just reported: _sort_relevance ranks on it and
+    # _get_nonredundant_features_relevance drops an ancestor on `<=`. Two nodes
+    # whose probabilities differ by the same amount (1/3 vs 1/6, and 2/3 vs 1/2)
+    # are mathematically tied; in float arithmetic the two subtractions round
+    # apart and the tie becomes a strict ordering decided by rounding rather
+    # than by the data. Exact Fractions keep the tie a tie.
+    # 3 present rows (1 positive) -> p1 = 1/3; 6 absent rows (1 positive) -> p2 = 1/6.
+    tied_a = np.array([[1], [1], [1], [0], [0], [0], [0], [0], [0]], dtype=bool)
+    y_a = np.array([1, 0, 0, 1, 0, 0, 0, 0, 0])
+    # 3 present rows (2 positive) -> p1 = 2/3; 2 absent rows (1 positive) -> p2 = 1/2.
+    tied_b = np.array([[1], [1], [1], [0], [0]], dtype=bool)
+    y_b = np.array([1, 1, 0, 1, 0])
+
+    assert get_relevance(tied_a, y_a, 0) == Fraction(1, 18)
+    assert get_relevance(tied_b, y_b, 0) == Fraction(1, 18)
+    assert get_relevance(tied_a, y_a, 0) == get_relevance(tied_b, y_b, 0)
+
+
 def test_information_gain(data2):
     X, y, _, _ = data2
     ig = information_gain(X, y)

--- a/scihfs/tests/test_helpers.py
+++ b/scihfs/tests/test_helpers.py
@@ -13,7 +13,12 @@ from scihfs.helpers import (
     get_relevance,
     shrink_dag,
 )
-from scihfs.metrics import conditional_mutual_information, gain_ratio, information_gain
+from scihfs.metrics import (
+    conditional_mutual_information,
+    gain_ratio,
+    information_gain,
+    pearson_correlation,
+)
 
 # ---------------------------------------------------------------------------
 # Independent reference oracles for the information-gain and gain ratio metrics, reproducing the
@@ -150,6 +155,18 @@ def test_gain_ratio_skips_empty_sparse_column():
     X = sparse.csc_matrix(np.array([[0, 1], [0, 0], [0, 1]]))
     y = np.array([0, 1, 0])
     assert gain_ratio(X, y)[0] == 0
+
+
+def test_pearson_correlation_accepts_sparse_columns():
+    # A selector (SHSEL's Correlation relevance_metric) passes sparse column
+    # slices directly; np.corrcoef itself has no sparse support, so
+    # pearson_correlation must densify just the two compared columns.
+    X_dense = np.array([[1, 1], [1, 0], [0, 0], [1, 1], [0, 1]], dtype=bool)
+    X_sparse = sparse.csc_matrix(X_dense)
+
+    dense_value = pearson_correlation(X_dense[:, 0], X_dense[:, 1])
+    sparse_value = pearson_correlation(X_sparse[:, 0], X_sparse[:, 1])
+    assert sparse_value == pytest.approx(dense_value)
 
 
 @pytest.mark.parametrize(

--- a/scihfs/tests/test_helpers.py
+++ b/scihfs/tests/test_helpers.py
@@ -191,6 +191,33 @@ def test_compute_aggregated_values(data, result, request):
     assert X.dtype == np.bool_
 
 
+@pytest.mark.parametrize(
+    "data, result",
+    [
+        ("data1", "result_aggregated1"),
+        ("data2", "result_aggregated2"),
+    ],
+)
+@pytest.mark.parametrize(
+    "sparse_type", [sparse.csr_array, sparse.csr_matrix], ids=["csr_array", "csr_matrix"]
+)
+def test_compute_aggregated_values_accepts_sparse_like_dense(
+    data, result, sparse_type, request
+):
+    # Sparse X must reproduce the exact dense result (and stay sparse: this
+    # was initially densified unconditionally via X.toarray()).
+    data = request.getfixturevalue(data)
+    result = request.getfixturevalue(result)
+    X, _, hierarchy, columns = data
+    hierarchy = add_virtual_root_node(nx.DiGraph(hierarchy))
+
+    X_transformed = compute_aggregated_values(sparse_type(X), hierarchy, columns)
+
+    assert sparse.issparse(X_transformed)
+    assert X_transformed.dtype == np.uint32
+    assert np.array_equal(X_transformed.toarray(), result)
+
+
 # ---------------------------------------------------------------------------
 # External oracle for the implementation of conditional mutual
 # information is the actively maintained ``dit`` package

--- a/scihfs/tests/test_hill_climbing.py
+++ b/scihfs/tests/test_hill_climbing.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from scipy import sparse
 
 from scihfs.selectors.hill_climbing import BottomUpSelector, TopDownSelector
 
@@ -34,6 +35,30 @@ def test_bottom_up_selection(data1, result_hill_selection_bu):
 
     support_mask = selector.get_support()
     assert np.array_equal(support_mask, support)
+
+
+@pytest.mark.parametrize(
+    "sparse_type", [sparse.csr_array, sparse.csr_matrix], ids=["csr_array", "csr_matrix"]
+)
+@pytest.mark.parametrize(
+    "Selector, kwargs", [(TopDownSelector, {}), (BottomUpSelector, {"k": 3})]
+)
+def test_hill_climbing_selectors_accept_sparse_like_dense(
+    data1, Selector, kwargs, sparse_type
+):
+    # compute_aggregated_values previously densified X unconditionally; this
+    # pins that a sparse fit reproduces the dense fit's selection exactly.
+    X, y, hierarchy, columns = data1
+
+    dense = Selector(hierarchy, **kwargs).fit(X, y, columns)
+    sparse_fit = Selector(hierarchy, **kwargs).fit(sparse_type(X), y, columns)
+
+    assert np.array_equal(sparse_fit.get_support(), dense.get_support())
+
+    sparse_transformed = sparse_fit.transform(sparse_type(X))
+    if sparse.issparse(sparse_transformed):
+        sparse_transformed = sparse_transformed.toarray()
+    assert np.array_equal(sparse_transformed, dense.transform(X))
 
 
 # Numerical input is currently not supported. Corresponding code is retained (but inactive) for future reintroduction.

--- a/scihfs/tests/test_shsel.py
+++ b/scihfs/tests/test_shsel.py
@@ -2,6 +2,7 @@ import networkx as nx
 import numpy as np
 import pandas as pd
 import pytest
+from scipy import sparse
 
 from scihfs.helpers import get_columns_for_numpy_hierarchy
 from scihfs.selectors import SHSELSelector
@@ -199,6 +200,32 @@ def test_SHSEL_selection_correlation_on_bool():
         [[1, 1, 0], [1, 0, 1], [0, 0, 1], [1, 0, 0], [0, 0, 0]], dtype=bool
     )
     assert np.array_equal(X_transformed, expected)
+
+
+@pytest.mark.parametrize(
+    "sparse_type", [sparse.csr_array, sparse.csr_matrix], ids=["csr_array", "csr_matrix"]
+)
+def test_SHSEL_selection_correlation_accepts_sparse_like_dense(sparse_type):
+    """The Correlation relevance_metric must not densify X to work: it slices
+    individual columns and previously crashed under np.corrcoef when those
+    slices were sparse (fixed in pearson_correlation)."""
+    edges = [(0, 1), (1, 2), (0, 3)]
+    hierarchy = nx.to_numpy_array(nx.DiGraph(edges))
+    columns = get_columns_for_numpy_hierarchy(nx.DiGraph(edges), 4)
+    X = np.array(
+        [[1, 1, 1, 0], [1, 1, 0, 1], [1, 0, 0, 1], [1, 1, 0, 0], [0, 0, 0, 0]],
+        dtype=bool,
+    )
+    y = np.array([1, 0, 0, 1, 0])
+
+    dense = SHSELSelector(
+        hierarchy, relevance_metric="Correlation", similarity_threshold=0.8
+    ).fit(X, y, columns)
+    sparse_fit = SHSELSelector(
+        hierarchy, relevance_metric="Correlation", similarity_threshold=0.8
+    ).fit(sparse_type(X), y, columns)
+
+    assert np.array_equal(sparse_fit.get_support(), dense.get_support())
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Added support for end-to-end handling of sparse datasets. Changes implemented:
- For **eager**:
  - `_compute_aggregated_values` (relevant for HillClimbing class) now branches on sparse vs. dense.
  - Pearson correlation (for SHSEL) now accepts sparse, densifies feature vectors internally.
- For **lazy**:
  - Removed explicit conversion of sparse data to arrays.
  - Added `_dense_row` to yield the 'densified' version of an instance from the sparse dataset.
  - Feature masks as result of _predict_ / _select_ are now sparse if the dataset input was sparse.
  - Relevance calculation now accepts both sparse and dense – also improved computational efficiency there.
  - `mean_selected_fraction` now accepts both sparse and dense (output from lazy methods).
  - (Temporary changes to HieAODE and TAN to maintain test success rate, but these two classes will be reiterated.)
- Updated the lazy HFS example.

Also renamed `self.representatives_` in eager (sub)classes to `self.selected_features_`.

Added corresponding tests to check intended behavior (LLM-generated, manually validated).

Closes #128 #132 